### PR TITLE
Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -88,6 +93,7 @@ dependencies = [
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-xml-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -153,6 +159,14 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -257,6 +271,14 @@ dependencies = [
 name = "linked-hash-map"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -436,6 +458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -678,6 +711,14 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -692,6 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
@@ -702,6 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dot_json 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79bae3be005c8e3f5832a46840c47d473538ee2d73956a9bebe16ebf9f5e3d0a"
 "checksum encode_unicode 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dda4963a6de8b990d05ae23b6d766dde2c65e84e35b297333d137535c65a212"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
+"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum find_git 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b917757416fe02ec0d303e669082fd04037d44c1a7cb170fc556a6f6889d3161"
@@ -716,6 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d3711dfd91a1081d2458ad2d06ea30a8755256e74038be2ad927d94e1c955ca8"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
@@ -739,6 +783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum serde 1.0.76 (registry+https://github.com/rust-lang/crates.io-index)" = "d00c69ae39089576cddfd235556e3b21bf41c2d80018063cb5ab8a1183c917fd"
+"checksum serde-xml-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4894572d6144e66305ffa041dbb4196bd857425340a88544b175c2a66b2daa38"
 "checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
@@ -770,5 +815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
+"checksum xml-rs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e1945e12e16b951721d7976520b0832496ef79c31602c7a29d950de79ba74621"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,9 @@ version = "0.1.0"
 dependencies = [
  "cirup_core 0.1.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -81,6 +83,7 @@ dependencies = [
  "dot_json 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "find_git 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -141,6 +144,18 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "env_logger"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +197,14 @@ dependencies = [
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "indexmap"
@@ -236,6 +259,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +315,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -481,6 +517,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,9 +647,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winreg"
@@ -640,11 +701,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef22b37c7a51c564a365892c012dc0271221fdcc64c69b19ba4d6fa8bd96d9c"
 "checksum dot_json 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79bae3be005c8e3f5832a46840c47d473538ee2d73956a9bebe16ebf9f5e3d0a"
 "checksum encode_unicode 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dda4963a6de8b990d05ae23b6d766dde2c65e84e35b297333d137535c65a212"
+"checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum find_git 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b917757416fe02ec0d303e669082fd04037d44c1a7cb170fc556a6f6889d3161"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -653,12 +716,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d3711dfd91a1081d2458ad2d06ea30a8755256e74038be2ad927d94e1c955ca8"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "34dc1f4f6dddab3bf008ecfd4fd2a631b585fbf0af123f34c1324f51a034ff5f"
 "checksum proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee80fbbe0ae60bcad82d15bc59d5fe2aaebc1b83fbfb145abc8c74f8e769549"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
@@ -682,6 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -700,7 +766,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cirup_cli"
 version = "0.1.0"
 dependencies = [
@@ -85,6 +95,7 @@ dependencies = [
 name = "cirup_core"
 version = "0.1.0"
 dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dot_json 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "find_git 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -311,6 +322,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
@@ -738,6 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef22b37c7a51c564a365892c012dc0271221fdcc64c69b19ba4d6fa8bd96d9c"
@@ -764,6 +789,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "34dc1f4f6dddab3bf008ecfd4fd2a631b585fbf0af123f34c1324f51a034ff5f"
 "checksum proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee80fbbe0ae60bcad82d15bc59d5fe2aaebc1b83fbfb145abc8c74f8e769549"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ remote_path = "git@bitbucket.org:devolutions/wayknow.git"
 [sync]
 # The source language
 source_language = "en"
+# The target language(s)
+target_languages = [ "fr", "de" ]
 # A regex to match your language files
 match_language_file = "\\.json$"
 # A regex to match the language from the language filename
@@ -27,17 +29,24 @@ working_dir = "/opt/wayk/i18n/WaykNow-Translations"
 ```
 ##### commands
 ###### vcs-log
-Show the version control history for the source language file.
-You must specify an old-commit, and optionally, a new-commit.
-###### vcs-diff
-Diff two commits of the source language file.
-You must specify an old-commit, and optionally, a new-commit.
-###### pull
-Generate translation files for all languages. 
-Translation files will contain all keys that have not been translated from the source language.
-If you specify a commit range (with old-commit, and optionally, new-commit), translation files will contain all keys that have either not been translated from the source language, or have been updated in the source language.
-###### push
-Merge all the translation files in the working directory back into version control.
+Show the version control history for the source language file. You must specify an old commit, and optionally, a new commit.
 
+Commits are listed, newest first, and formatted as:
+`%commit - %date - %author - %message`
+
+You can limit the number of commits returned with `--limit`
+
+e.g. `cirup vcs-log --old-commit ac8d579fd --limit 20`
+
+###### vcs-diff
+Diff two commits of the source language file. You must specify an old commit, and optionally, a new commit.
+###### pull
+Generate translation files for all target languages. You can specify a commit range.
+Translation files will contain all keys that have not been translated from the source language. You can also include strings that have changed in the commit range using `--show-changes`.
+
+e.g. `cirup pull --old-commit ac8d579fd --show-changes`
+###### push
+Merge the translation files in the working directory back into version control.
+You can specify a commit range to merge a specific set of changes.
 ##### other commands
 There are other useful commands available that perform operations on individual files using the cirup engine. Check the command line help.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 A translation continuous integration tool
 
-### warning
-Before data is downloaded, all unversioned files in the working directory are removed, and pending rebase is aborted, so the working directory should not be the one you are doing any development in.
-
 ##### configuration
 A configuration file is required for most operations:
  ```
@@ -20,9 +17,9 @@ remote_path = "git@bitbucket.org:devolutions/wayknow.git"
 # The source language
 source_language = "en"
 # A regex to match your language files
-source_match = "\\.json$"
+match_language_file = "\\.json$"
 # A regex to match the language from the language filename
-source_name_match = "(.+?)(\\.[^.]*$|$)"
+match_language_name = "(.+?)(\\.[^.]*$|$)"
 # The relative path to the language files in the repository
 source_dir = "resources/i18n"
 # The location to export and import translations from

--- a/cirup_cli/Cargo.toml
+++ b/cirup_cli/Cargo.toml
@@ -10,6 +10,8 @@ path = "src/main.rs"
 [dependencies]
 lazy_static = "1.0"
 clap = { version = "2.31", features = ["yaml"] }
+log = "0.4"
+env_logger = "0.6.0"
 
 [dependencies.cirup_core]
 path = "../cirup_core"

--- a/cirup_cli/Cargo.toml
+++ b/cirup_cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cirup_cli"
 version = "0.1.0"
 authors = ["Marc-André Moreau <marcandre.moreau@gmail.com>"]
+edition = "2018"
 
 [[bin]]
 name = "cirup"

--- a/cirup_cli/src/cli.yml
+++ b/cirup_cli/src/cli.yml
@@ -40,7 +40,13 @@ subcommands:
     - push:
         about: "merge translations from working_dir back into source control. [config] is required."
     - vcs-log:
-        about: "show the version control history of the source language. [config] is required."
+        about: "show the version control history of the source language, newest first. [config] is required."
+        args:
+            - limit:
+                long: limit
+                short: l
+                takes_value: true
+                help: "limit the number of results returned"
     - vcs-diff:
         about: "diff two commits of the source language. [config] is required. [old-commit] is required."
     - file-print:

--- a/cirup_cli/src/cli.yml
+++ b/cirup_cli/src/cli.yml
@@ -33,7 +33,7 @@ args:
             takes_value: false
             global: true
             help: "additionally print keys that have values in [file2] but that do not match the values in [file1]. 
-            this is useful for finding update translations when comparing two versions of the same language."
+            this is useful for finding translations that need updating."
 subcommands:
     - pull:
         about: "generate translations for all languages into working_dir. [config] is required."

--- a/cirup_cli/src/cli.yml
+++ b/cirup_cli/src/cli.yml
@@ -5,6 +5,7 @@ args:
         - verbose:
             short: v
             multiple: true
+            global: true
             help: Sets the level of verbosity
         - config:
             long: config
@@ -39,12 +40,6 @@ subcommands:
                 help: "force the translations to be merged, even if they seem to match the source language"
     - vcs-log:
         about: "show the version control history of the source language. [config] is required."
-        args:
-            - format:
-                long: format
-                short: f
-                takes_value: true
-                default_value: oneline
     - vcs-diff:
         about: "diff two commits of the source language. [config] is required. [old-commit] is required."
     - file-print:

--- a/cirup_cli/src/cli.yml
+++ b/cirup_cli/src/cli.yml
@@ -2,6 +2,10 @@ name: cirup
 author: Marc-André Moreau <marcandre.moreau@gmail.com>
 about: a translation continuous integration tool
 args:
+        - verbose:
+            short: v
+            multiple: true
+            help: Sets the level of verbosity
         - config:
             long: config
             short: c

--- a/cirup_cli/src/cli.yml
+++ b/cirup_cli/src/cli.yml
@@ -27,17 +27,18 @@ args:
                 - old_commit
             global: true
             help: a git hash specifying the new commit
+        - show_changes:
+            long: show-changes
+            short: C
+            takes_value: false
+            global: true
+            help: "additionally print keys that have values in [file2] but that do not match the values in [file1]. 
+            this is useful for finding update translations when comparing two versions of the same language."
 subcommands:
     - pull:
-        about: "generate translations for all languages into working_dir"
+        about: "generate translations for all languages into working_dir. [config] is required."
     - push:
         about: "merge translations from working_dir back into source control. [config] is required."
-        args:
-            - force:
-                long: force
-                short: F
-                takes_value: false
-                help: "force the translations to be merged, even if they seem to match the source language"
     - vcs-log:
         about: "show the version control history of the source language. [config] is required."
     - vcs-diff:
@@ -79,14 +80,8 @@ subcommands:
             - output:
                 index: 3
                 takes_value: true
-            - show_changes:
-                long: show-changes
-                short: C
-                takes_value: false
-                help: "additionally print keys that have values in [file2] but that do not match the values in [file1]. 
-                this is useful for finding update translations when comparing two versions of the same language."
     - file-merge:
-        about: merges the values from [file1] and [file2]
+        about: merges the values from [file2] into [file1]
         args:
             - file1:
                 index: 1

--- a/cirup_cli/src/main.rs
+++ b/cirup_cli/src/main.rs
@@ -52,89 +52,110 @@ fn convert(file_one: &str, out_file: &str) {
 
 fn run(matches: &clap::ArgMatches, config: Option<Config>) -> Result<(), Box<Error>> {
     match matches.subcommand() {
-        ("file-print", Some(args)) => { 
+        ("file-print", Some(args)) => {
             print(args.value_of("file").unwrap(), args.value_of("output"));
             Ok(())
-        },
-        ("file-diff", Some(args)) => { 
-            if args.is_present("show_changes") {
-                change(args.value_of("file1").unwrap(), args.value_of("file2").unwrap(), args.value_of("output"));
-            } else {
-                diff(args.value_of("file1").unwrap(), args.value_of("file2").unwrap(), args.value_of("output"));
-            }
-            Ok(())
-        },
-        ("file-merge", Some(args)) => {
-            merge(args.value_of("file1").unwrap(), args.value_of("file2").unwrap(), args.value_of("output"));
-            Ok(())
-        },
-        ("file-intersect", Some(args)) => {
-            intersect(args.value_of("file1").unwrap(), args.value_of("file2").unwrap(), args.value_of("output"));
-            Ok(())
-        },
-        ("file-subtract", Some(args)) => {
-            subtract(args.value_of("file1").unwrap(), args.value_of("file2").unwrap(), args.value_of("output"));
-            Ok(())
-        },
-        ("file-convert", Some(args)) => {
-            convert(args.value_of("file").unwrap(), args.value_of("output").unwrap());
-            Ok(())
-        },
-        ("vcs-log", Some(args)) => {
-            match config {
-                Some(c) => {
-                    let sync = Sync::new(&c)?;
-
-                    sync.vcs.log(
-                        &sync.source_language_path().to_string_lossy(), 
-                        args.value_of("format"), 
-                        args.value_of("old_commit"), 
-                        args.value_of("new_commit"), 
-                        true)?;
-
-                    Ok(())
-                },
-                None => { Err("configuration file required")? }
-            }
-        },
-        ("vcs-diff", Some(args)) => {
-            match config {
-                Some(c) => {
-                    let sync = Sync::new(&c)?;
-
-                    sync.vcs.diff(
-                        &sync.source_language_path().to_string_lossy(), 
-                        args.value_of("old_commit").unwrap(), 
-                        args.value_of("new_commit"), )?;
-
-                    Ok(())
-                },
-                None => { Err("configuration file required")? }
-            }
-        },
-        ("pull", Some(args)) => {
-            match config {
-                Some(c) => {
-                    let sync = Sync::new(&c)?;
-                    sync.pull(args.value_of("old_commit"), args.value_of("new_commit"), args.is_present("show_changes"))?;
-
-                    Ok(())
-                },
-                None => { Err("configuration file required")? }
-            }
-        },
-        ("push", Some(args)) => {
-            match config {
-                Some(c) => {
-                    let sync = Sync::new(&c)?;
-                    sync.push(args.value_of("old_commit"), args.value_of("new_commit"))?;
-
-                    Ok(())
-                },
-                None => { Err("configuration file required")? }
-            }
         }
-        _ => { Err("unrecognised subcommand")? },
+        ("file-diff", Some(args)) => {
+            if args.is_present("show_changes") {
+                change(
+                    args.value_of("file1").unwrap(),
+                    args.value_of("file2").unwrap(),
+                    args.value_of("output"),
+                );
+            } else {
+                diff(
+                    args.value_of("file1").unwrap(),
+                    args.value_of("file2").unwrap(),
+                    args.value_of("output"),
+                );
+            }
+            Ok(())
+        }
+        ("file-merge", Some(args)) => {
+            merge(
+                args.value_of("file1").unwrap(),
+                args.value_of("file2").unwrap(),
+                args.value_of("output"),
+            );
+            Ok(())
+        }
+        ("file-intersect", Some(args)) => {
+            intersect(
+                args.value_of("file1").unwrap(),
+                args.value_of("file2").unwrap(),
+                args.value_of("output"),
+            );
+            Ok(())
+        }
+        ("file-subtract", Some(args)) => {
+            subtract(
+                args.value_of("file1").unwrap(),
+                args.value_of("file2").unwrap(),
+                args.value_of("output"),
+            );
+            Ok(())
+        }
+        ("file-convert", Some(args)) => {
+            convert(
+                args.value_of("file").unwrap(),
+                args.value_of("output").unwrap(),
+            );
+            Ok(())
+        }
+        ("vcs-log", Some(args)) => match config {
+            Some(c) => {
+                let sync = Sync::new(&c)?;
+
+                sync.vcs.log(
+                    &sync.source_language_path().to_string_lossy(),
+                    args.value_of("format"),
+                    args.value_of("old_commit"),
+                    args.value_of("new_commit"),
+                    true,
+                )?;
+
+                Ok(())
+            }
+            None => Err("configuration file required")?,
+        },
+        ("vcs-diff", Some(args)) => match config {
+            Some(c) => {
+                let sync = Sync::new(&c)?;
+
+                sync.vcs.diff(
+                    &sync.source_language_path().to_string_lossy(),
+                    args.value_of("old_commit").unwrap(),
+                    args.value_of("new_commit"),
+                )?;
+
+                Ok(())
+            }
+            None => Err("configuration file required")?,
+        },
+        ("pull", Some(args)) => match config {
+            Some(c) => {
+                let sync = Sync::new(&c)?;
+                sync.pull(
+                    args.value_of("old_commit"),
+                    args.value_of("new_commit"),
+                    args.is_present("show_changes"),
+                )?;
+
+                Ok(())
+            }
+            None => Err("configuration file required")?,
+        },
+        ("push", Some(args)) => match config {
+            Some(c) => {
+                let sync = Sync::new(&c)?;
+                sync.push(args.value_of("old_commit"), args.value_of("new_commit"))?;
+
+                Ok(())
+            }
+            None => Err("configuration file required")?,
+        },
+        _ => Err("unrecognised subcommand")?,
     }
 }
 
@@ -152,17 +173,17 @@ fn main() {
     let mut builder = Builder::from_env(Env::default().default_filter_or(min_log_level));
     builder.init();
 
-    let mut config : Option<Config> = None;
+    let mut config: Option<Config> = None;
 
     if let Some(config_file) = matches.value_of("config") {
         match Config::new(Path::new(config_file)) {
-            Ok(c) => { config = Some(c) },
-            Err(e) => { error!("unable to read the config file ({})", e) }
+            Ok(c) => config = Some(c),
+            Err(e) => error!("unable to read the config file ({})", e),
         }
     }
 
     match run(&matches, config) {
-        Ok(()) => { return }
-        Err(e) => { error!("an unexpected error occured ({})", e) }
+        Ok(()) => return,
+        Err(e) => error!("an unexpected error occured ({})", e),
     }
 }

--- a/cirup_cli/src/main.rs
+++ b/cirup_cli/src/main.rs
@@ -1,11 +1,15 @@
 #[macro_use]
 extern crate clap;
 extern crate cirup_core;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
 
 use std::error::Error;
 use std::path::Path;
 
 use clap::App;
+use env_logger::{Builder, Env};
 
 use cirup_core::config::Config;
 use cirup_core::query;
@@ -147,6 +151,15 @@ fn main() {
     let yaml = load_yaml!("cli.yml");
     let app = App::from_yaml(yaml);
     let matches = app.version(crate_version!()).get_matches();
+
+    let min_log_level = match matches.occurrences_of("verbose") {
+        0 => "info",
+        1 => "debug",
+        2 | _ => "trace",
+    };
+
+    let mut builder = Builder::from_env(Env::default().default_filter_or(min_log_level));
+    builder.init();
 
     let mut config : Option<Config> = None;
 

--- a/cirup_cli/src/main.rs
+++ b/cirup_cli/src/main.rs
@@ -14,7 +14,6 @@ use env_logger::{Builder, Env};
 use cirup_core::config::Config;
 use cirup_core::query;
 use cirup_core::sync::Sync;
-use cirup_core::vcs;
 
 fn print(input: &str, out_file: Option<&str>) {
     let query = query::query_print(input);
@@ -85,12 +84,8 @@ fn run(matches: &clap::ArgMatches, config: Option<Config>) -> Result<(), Box<Err
             match config {
                 Some(c) => {
                     let sync = Sync::new(&c)?;
-                    let vcs = vcs::new(&c)?;
 
-                    println!("source language is {:?}", sync.source_language_path());
-
-                    vcs.pull()?;  
-                    vcs.log(
+                    sync.vcs.log(
                         &sync.source_language_path().to_string_lossy(), 
                         args.value_of("format"), 
                         args.value_of("old_commit"), 
@@ -106,12 +101,8 @@ fn run(matches: &clap::ArgMatches, config: Option<Config>) -> Result<(), Box<Err
             match config {
                 Some(c) => {
                     let sync = Sync::new(&c)?;
-                    let vcs = vcs::new(&c)?;
 
-                    println!("source language is {:?}", sync.source_language_path());
-
-                    vcs.pull()?;  
-                    vcs.diff(
+                    sync.vcs.diff(
                         &sync.source_language_path().to_string_lossy(), 
                         args.value_of("old_commit").unwrap(), 
                         args.value_of("new_commit"), )?;
@@ -166,12 +157,12 @@ fn main() {
     if let Some(config_file) = matches.value_of("config") {
         match Config::new(Path::new(config_file)) {
             Ok(c) => { config = Some(c) },
-            Err(e) => { println!("failed to read config file: {:?}", e) }
+            Err(e) => { error!("unable to read the config file ({})", e) }
         }
     }
 
     match run(&matches, config) {
         Ok(()) => { return }
-        Err(e) => { println!("{}", e)}
+        Err(e) => { error!("an unexpected error occured ({})", e) }
     }
 }

--- a/cirup_cli/src/main.rs
+++ b/cirup_cli/src/main.rs
@@ -116,7 +116,7 @@ fn run(matches: &clap::ArgMatches, config: Option<Config>) -> Result<(), Box<Err
             match config {
                 Some(c) => {
                     let sync = Sync::new(&c)?;
-                    sync.pull(args.value_of("old_commit"), args.value_of("new_commit"))?;
+                    sync.pull(args.value_of("old_commit"), args.value_of("new_commit"), args.is_present("show_changes"))?;
 
                     Ok(())
                 },
@@ -127,7 +127,7 @@ fn run(matches: &clap::ArgMatches, config: Option<Config>) -> Result<(), Box<Err
             match config {
                 Some(c) => {
                     let sync = Sync::new(&c)?;
-                    sync.push(args.is_present("force"))?;
+                    sync.push(args.value_of("old_commit"), args.value_of("new_commit"))?;
 
                     Ok(())
                 },

--- a/cirup_cli/src/main.rs
+++ b/cirup_cli/src/main.rs
@@ -113,6 +113,7 @@ fn run(matches: &clap::ArgMatches, config: Option<Config>) -> Result<(), Box<Err
                     args.value_of("old_commit"),
                     args.value_of("new_commit"),
                     true,
+                    value_t!(args, "limit", u32).unwrap_or(0),
                 )?;
 
                 Ok(())

--- a/cirup_core/Cargo.toml
+++ b/cirup_core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Marc-André Moreau <marcandre.moreau@gmail.com>"]
 
 [dependencies]
+chrono = "0.4"
 regex = "1.0"
 serde = "^1.0"
 serde_derive = "^1.0"

--- a/cirup_core/Cargo.toml
+++ b/cirup_core/Cargo.toml
@@ -14,6 +14,7 @@ lazy_static = "1.0.0"
 prettytable-rs = "^0.6"
 find_git = "1.2.0"
 tempfile = "3.0.4"
+log = "0.4"
 
 [dependencies.uuid]
 version = "0.6"

--- a/cirup_core/Cargo.toml
+++ b/cirup_core/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Marc-André Moreau <marcandre.moreau@gmail.com>"]
 regex = "1.0"
 serde = "^1.0"
 serde_derive = "^1.0"
+serde-xml-rs = "0.3.0"
 toml = "^0.4"
 xml-rs = "0.8.0"
 dot_json = "0.2.0"

--- a/cirup_core/src/config.rs
+++ b/cirup_core/src/config.rs
@@ -20,8 +20,9 @@ pub struct Vcs {
 #[derive(Serialize,Deserialize)]
 pub struct Sync {
     pub source_language: String,
-    pub source_match: String,
-    pub source_name_match: String,
+    pub target_languages: Vec<String>,
+    pub match_language_file: String,
+    pub match_language_name: String,
     pub source_dir: String,
     pub working_dir: String,
 }
@@ -29,7 +30,12 @@ pub struct Sync {
 impl Config {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Box<Error>> {
         let contents = fs::read_to_string(path)?;
-        Config::new_from_string(&contents)
+        let config = Config::new_from_string(&contents)?;
+
+        info!("source language: {}", config.sync.source_language);
+        info!("target language(s): {}", config.sync.target_languages.join(" "));
+
+        Ok(config)
     }
 
     pub fn new_from_string(contents: &str) -> Result<Self, Box<Error>> {
@@ -55,8 +61,9 @@ fn config_write() {
         },
         sync: Sync {
             source_language: "en".to_string(),
-            source_match: "\\.json$".to_string(),
-            source_name_match: "(.+?)(\\.[^.]*$|$)".to_string(),
+            target_languages: vec!["fr".to_string(), "de".to_string()],
+            match_language_file: "\\.json$".to_string(),
+            match_language_name: "(.+?)(\\.[^.]*$|$)".to_string(),
             source_dir: "xxx".to_string(),
             working_dir: "xxx".to_string(),
         },

--- a/cirup_core/src/config.rs
+++ b/cirup_core/src/config.rs
@@ -1,23 +1,23 @@
+use std::error::Error;
 use std::fs;
 use std::path::Path;
-use std::error::Error;
 
 use toml;
 
-#[derive(Serialize,Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Config {
     pub vcs: Vcs,
     pub sync: Sync,
 }
 
-#[derive(Serialize,Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Vcs {
     pub plugin: String,
     pub local_path: String,
     pub remote_path: String,
 }
 
-#[derive(Serialize,Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Sync {
     pub source_language: String,
     pub target_languages: Vec<String>,
@@ -33,7 +33,10 @@ impl Config {
         let config = Config::new_from_string(&contents)?;
 
         info!("source language: {}", config.sync.source_language);
-        info!("target language(s): {}", config.sync.target_languages.join(" "));
+        info!(
+            "target language(s): {}",
+            config.sync.target_languages.join(" ")
+        );
 
         Ok(config)
     }

--- a/cirup_core/src/error.rs
+++ b/cirup_core/src/error.rs
@@ -1,7 +1,6 @@
-
-use std::io;
-use std::fmt;
 use std::error;
+use std::fmt;
+use std::io;
 
 #[derive(Debug)]
 pub enum CirupError {

--- a/cirup_core/src/file.rs
+++ b/cirup_core/src/file.rs
@@ -1,18 +1,17 @@
-
 use std::fs;
+use std::io::prelude::*;
 use std::io::Read;
 use std::path::Path;
-use std::io::prelude::*;
 
 use std::collections::HashMap;
 use std::sync::Mutex;
 use uuid::Uuid;
 
-use Resource;
-use std::error::Error;
 use json::JsonFileFormat;
-use resx::ResxFileFormat;
 use restext::RestextFileFormat;
+use resx::ResxFileFormat;
+use std::error::Error;
+use Resource;
 
 pub enum FormatType {
     Unknown,
@@ -32,18 +31,10 @@ pub trait FileFormat {
 
 pub fn get_format_type_from_extension(extension: &str) -> FormatType {
     match extension {
-        JsonFileFormat::EXTENSION => {
-            FormatType::Json
-        },
-        ResxFileFormat::EXTENSION => {
-            FormatType::Resx
-        },
-        RestextFileFormat::EXTENSION => {
-            FormatType::Restext
-        },
-        _ => {
-            FormatType::Unknown
-        }
+        JsonFileFormat::EXTENSION => FormatType::Json,
+        ResxFileFormat::EXTENSION => FormatType::Resx,
+        RestextFileFormat::EXTENSION => FormatType::Restext,
+        _ => FormatType::Unknown,
     }
 }
 
@@ -65,20 +56,18 @@ pub fn save_string_to_file(filename: &str, text: &str) {
 pub fn load_resource_str(text: &str, extension: &str) -> Result<Vec<Resource>, Box<Error>> {
     match extension {
         JsonFileFormat::EXTENSION => {
-            let file_format = JsonFileFormat { };
+            let file_format = JsonFileFormat {};
             file_format.parse_from_str(text)
-        },
-        ResxFileFormat::EXTENSION => {
-            let file_format = ResxFileFormat { };
-            file_format.parse_from_str(text)
-        },
-        RestextFileFormat::EXTENSION => {
-            let file_format = RestextFileFormat { };
-            file_format.parse_from_str(text)
-        },
-        _ => {
-            Ok(Vec::new())
         }
+        ResxFileFormat::EXTENSION => {
+            let file_format = ResxFileFormat {};
+            file_format.parse_from_str(text)
+        }
+        RestextFileFormat::EXTENSION => {
+            let file_format = RestextFileFormat {};
+            file_format.parse_from_str(text)
+        }
+        _ => Ok(Vec::new()),
     }
 }
 
@@ -87,20 +76,18 @@ pub fn load_resource_file(filename: &str) -> Result<Vec<Resource>, Box<Error>> {
     let extension = path.extension().unwrap().to_str().unwrap();
     match extension {
         JsonFileFormat::EXTENSION => {
-            let file_format = JsonFileFormat { };
+            let file_format = JsonFileFormat {};
             file_format.parse_from_file(filename)
-        },
-        ResxFileFormat::EXTENSION => {
-            let file_format = ResxFileFormat { };
-            file_format.parse_from_file(filename)
-        },
-        RestextFileFormat::EXTENSION => {
-            let file_format = RestextFileFormat { };
-            file_format.parse_from_file(filename)
-        },
-        _ => {
-            Ok(Vec::new())
         }
+        ResxFileFormat::EXTENSION => {
+            let file_format = ResxFileFormat {};
+            file_format.parse_from_file(filename)
+        }
+        RestextFileFormat::EXTENSION => {
+            let file_format = RestextFileFormat {};
+            file_format.parse_from_file(filename)
+        }
+        _ => Ok(Vec::new()),
     }
 }
 
@@ -109,20 +96,18 @@ pub fn save_resource_file(filename: &str, resources: &Vec<Resource>) {
     let extension = path.extension().unwrap().to_str().unwrap();
     match extension {
         JsonFileFormat::EXTENSION => {
-            let file_format = JsonFileFormat { };
+            let file_format = JsonFileFormat {};
             file_format.write_to_file(filename, resources)
-        },
-        ResxFileFormat::EXTENSION => {
-            let file_format = ResxFileFormat { };
-            file_format.write_to_file(filename, resources)
-        },
-        RestextFileFormat::EXTENSION => {
-            let file_format = RestextFileFormat { };
-            file_format.write_to_file(filename, resources)
-        },
-        _ => {
-
         }
+        ResxFileFormat::EXTENSION => {
+            let file_format = ResxFileFormat {};
+            file_format.write_to_file(filename, resources)
+        }
+        RestextFileFormat::EXTENSION => {
+            let file_format = RestextFileFormat {};
+            file_format.write_to_file(filename, resources)
+        }
+        _ => {}
     }
 }
 

--- a/cirup_core/src/json.rs
+++ b/cirup_core/src/json.rs
@@ -1,39 +1,40 @@
-
+extern crate dot_json;
 extern crate serde;
 extern crate serde_json;
-extern crate dot_json;
 
-use serde::{Serialize};
-use serde_json::{Value, Map};
 use dot_json::value_to_dot;
+use serde::Serialize;
+use serde_json::{Map, Value};
 
-use Resource;
-use std::error::Error;
-use file::{FileFormat, FormatType};
 use file::{load_string_from_file, save_string_to_file};
+use file::{FileFormat, FormatType};
+use std::error::Error;
+use Resource;
 
-pub struct JsonFileFormat {
+pub struct JsonFileFormat {}
 
-}
-
-fn json_dot_insert(root_map: &mut Map<String,Value>, name: &str, value: &str) {
+fn json_dot_insert(root_map: &mut Map<String, Value>, name: &str, value: &str) {
     if let Some(dot_index) = name.find('.') {
         let root_path = &name[0..dot_index];
-        let child_path = &name[dot_index+1..name.len()];
+        let child_path = &name[dot_index + 1..name.len()];
 
         if !root_map.contains_key(root_path) {
-            let child_map: Map<String,Value> = Map::new();
+            let child_map: Map<String, Value> = Map::new();
             root_map.insert(root_path.to_string(), Value::Object(child_map));
         }
 
-        let mut child_map = root_map.get_mut(root_path).unwrap().as_object_mut().unwrap();
+        let mut child_map = root_map
+            .get_mut(root_path)
+            .unwrap()
+            .as_object_mut()
+            .unwrap();
         json_dot_insert(&mut child_map, child_path, value);
     } else {
         root_map.insert(name.to_string(), Value::String(value.to_string()));
     }
 }
 
-fn json_to_string_pretty(value: &Map<String,Value>) -> String {
+fn json_to_string_pretty(value: &Map<String, Value>) -> String {
     let writer = Vec::new();
     let formatter = serde_json::ser::PrettyFormatter::with_indent(b"    ");
     let mut ser = serde_json::Serializer::with_formatter(writer, formatter);
@@ -42,7 +43,6 @@ fn json_to_string_pretty(value: &Map<String,Value>) -> String {
 }
 
 impl FileFormat for JsonFileFormat {
-
     const EXTENSION: &'static str = "json";
     const TYPE: FormatType = FormatType::Json;
 
@@ -64,7 +64,7 @@ impl FileFormat for JsonFileFormat {
     }
 
     fn write_to_str(&self, resources: &Vec<Resource>) -> String {
-        let mut root_map: Map<String,Value> = Map::new();
+        let mut root_map: Map<String, Value> = Map::new();
 
         for resource in resources {
             json_dot_insert(&mut root_map, &resource.name, &resource.value);
@@ -98,7 +98,7 @@ fn test_json_parse() {
 }
     "#;
 
-    let file_format = JsonFileFormat { };
+    let file_format = JsonFileFormat {};
 
     let resources = file_format.parse_from_str(&text).unwrap();
 
@@ -129,8 +129,7 @@ fn test_json_parse() {
 
 #[test]
 fn test_json_write() {
-
-    let file_format = JsonFileFormat { };
+    let file_format = JsonFileFormat {};
 
     let resources = vec![
         Resource::new("lblBoat", "I'm on a boat."),

--- a/cirup_core/src/lib.rs
+++ b/cirup_core/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate regex;
 extern crate treexml;
 extern crate uuid;
+extern crate chrono;
 
 #[macro_use]
 extern crate serde_derive;

--- a/cirup_core/src/lib.rs
+++ b/cirup_core/src/lib.rs
@@ -1,17 +1,16 @@
-
-extern crate uuid;
 extern crate regex;
 extern crate treexml;
+extern crate uuid;
 
 #[macro_use]
 extern crate serde_derive;
-extern crate toml;
+extern crate dot_json;
+extern crate rusqlite;
 extern crate serde;
 extern crate serde_json;
 extern crate serde_xml_rs;
-extern crate dot_json;
 extern crate tempfile;
-extern crate rusqlite;
+extern crate toml;
 #[macro_use]
 extern crate log;
 
@@ -24,13 +23,13 @@ extern crate lazy_static;
 mod resource;
 use resource::Resource;
 
+pub mod config;
 mod error;
 mod shell;
-pub mod config;
 
 mod json;
-mod resx;
 mod restext;
+mod resx;
 
 mod file;
 mod vtab;
@@ -38,6 +37,6 @@ mod vtab;
 pub mod query;
 
 mod revision;
+pub mod sync;
 mod utils;
 pub mod vcs;
-pub mod sync;

--- a/cirup_core/src/lib.rs
+++ b/cirup_core/src/lib.rs
@@ -38,3 +38,5 @@ pub mod query;
 
 pub mod vcs;
 pub mod sync;
+
+mod utils;

--- a/cirup_core/src/lib.rs
+++ b/cirup_core/src/lib.rs
@@ -21,22 +21,23 @@ extern crate prettytable;
 #[macro_use]
 extern crate lazy_static;
 
-pub mod resource;
+mod resource;
 use resource::Resource;
 
-pub mod error;
-pub mod shell;
+mod error;
+mod shell;
 pub mod config;
 
-pub mod json;
-pub mod resx;
-pub mod restext;
+mod json;
+mod resx;
+mod restext;
 
-pub mod file;
-pub mod vtab;
+mod file;
+mod vtab;
+
 pub mod query;
 
+mod revision;
+mod utils;
 pub mod vcs;
 pub mod sync;
-
-mod utils;

--- a/cirup_core/src/lib.rs
+++ b/cirup_core/src/lib.rs
@@ -9,10 +9,10 @@ extern crate toml;
 extern crate serde;
 extern crate serde_json;
 extern crate dot_json;
-
 extern crate tempfile;
-
 extern crate rusqlite;
+#[macro_use]
+extern crate log;
 
 #[macro_use]
 extern crate prettytable;

--- a/cirup_core/src/lib.rs
+++ b/cirup_core/src/lib.rs
@@ -8,6 +8,7 @@ extern crate serde_derive;
 extern crate toml;
 extern crate serde;
 extern crate serde_json;
+extern crate serde_xml_rs;
 extern crate dot_json;
 extern crate tempfile;
 extern crate rusqlite;

--- a/cirup_core/src/query.rs
+++ b/cirup_core/src/query.rs
@@ -169,9 +169,9 @@ const CHANGE_QUERY : &str = r"
         LEFT OUTER JOIN B ON A.key = B.key 
         WHERE (B.val IS NULL) OR (A.val <> B.val)";
 const MERGE_QUERY : &str = r"
-        SELECT * FROM A LEFT OUTER JOIN B ON A.key = B.key
-        UNION
-        SELECT * FROM B LEFT OUTER JOIN A ON A.key = B.key";
+        SELECT A.key, CASE WHEN B.val IS NOT NULL THEN B.val ELSE A.val END
+        FROM A
+        LEFT OUTER JOIN B on A.key = B.key";
 const INTERSECT_QUERY : &str = r"
         SELECT * FROM A 
         INTERSECT 

--- a/cirup_core/src/query.rs
+++ b/cirup_core/src/query.rs
@@ -88,9 +88,9 @@ pub fn execute_query(db: &Connection, query: &str) {
         Err(e) => {
             match e {
                 Error::SqliteFailure(_r, m) => {
-                    if let Some(msg) = m { println!("{}", msg) };
+                    if let Some(msg) = m { error!("{}", msg) };
                 },
-                _ => println!("{:?}", Error::ModuleError(format!("{}", e)))
+                _ => error!("{:?}", Error::ModuleError(format!("{}", e)))
             }
         }
     }

--- a/cirup_core/src/query.rs
+++ b/cirup_core/src/query.rs
@@ -166,7 +166,12 @@ const CHANGE_QUERY: &str = r"
 const MERGE_QUERY: &str = r"
         SELECT A.key, CASE WHEN B.val IS NOT NULL THEN B.val ELSE A.val END
         FROM A
-        LEFT OUTER JOIN B on A.key = B.key";
+        LEFT OUTER JOIN B on A.key = B.key
+        UNION
+        SELECT B.key, B.val
+        FROM B
+        LEFT OUTER JOIN A on A.key = B.key
+        WHERE (A.key IS NULL)";
 const INTERSECT_QUERY: &str = r"
         SELECT * FROM A 
         INTERSECT 

--- a/cirup_core/src/restext.rs
+++ b/cirup_core/src/restext.rs
@@ -1,13 +1,12 @@
-
 use regex::Regex;
 use std::fmt;
 use std::fs;
 use std::io::prelude::*;
 
-use Resource;
-use std::error::Error;
+use file::load_string_from_file;
 use file::{FileFormat, FormatType};
-use file::{load_string_from_file};
+use std::error::Error;
+use Resource;
 
 /**
  * .restext file format:
@@ -19,9 +18,7 @@ lazy_static! {
     static ref REGEX_RESTEXT: Regex = Regex::new(r"^\s*(\w+)=(.*)$").unwrap();
 }
 
-pub struct RestextFileFormat {
-
-}
+pub struct RestextFileFormat {}
 
 /* https://lise-henry.github.io/articles/optimising_strings.html */
 
@@ -32,14 +29,13 @@ pub fn escape_newlines(input: &str) -> String {
             '\\' => output.push_str("\\\\"),
             '\r' => output.push_str("\\r"),
             '\n' => output.push_str("\\n"),
-            _ => output.push(c)
+            _ => output.push(c),
         }
     }
     output
 }
 
 impl FileFormat for RestextFileFormat {
-
     const EXTENSION: &'static str = "restext";
     const TYPE: FormatType = FormatType::Restext;
 
@@ -69,8 +65,11 @@ impl FileFormat for RestextFileFormat {
 
         for resource in resources {
             let escaped_value = escape_newlines(resource.value.as_str());
-            fmt::write(&mut output, format_args!("{}={}\r\n",
-                resource.name, escaped_value)).unwrap();
+            fmt::write(
+                &mut output,
+                format_args!("{}={}\r\n", resource.name, escaped_value),
+            )
+            .unwrap();
         }
 
         output
@@ -87,12 +86,11 @@ impl FileFormat for RestextFileFormat {
 
 #[test]
 fn test_restext_parse() {
-    let text =
-"lblBoat=I'm on a boat.\r\n\
-lblYolo=You only live once\r\n\
-lblDogs=Who let the dogs out?\r\n";
+    let text = "lblBoat=I'm on a boat.\r\n\
+                lblYolo=You only live once\r\n\
+                lblDogs=Who let the dogs out?\r\n";
 
-    let file_format = RestextFileFormat { };
+    let file_format = RestextFileFormat {};
 
     let resources = file_format.parse_from_str(&text).unwrap();
 
@@ -111,8 +109,7 @@ lblDogs=Who let the dogs out?\r\n";
 
 #[test]
 fn test_restext_write() {
-
-    let file_format = RestextFileFormat { };
+    let file_format = RestextFileFormat {};
 
     let resources = vec![
         Resource::new("lblBoat", "I'm on a boat."),
@@ -120,10 +117,9 @@ fn test_restext_write() {
         Resource::new("lblDogs", "Who let the dogs out?"),
     ];
 
-    let expected_text =
-"lblBoat=I'm on a boat.\r\n\
-lblYolo=You only live once\r\n\
-lblDogs=Who let the dogs out?\r\n";
+    let expected_text = "lblBoat=I'm on a boat.\r\n\
+                         lblYolo=You only live once\r\n\
+                         lblDogs=Who let the dogs out?\r\n";
 
     let actual_text = file_format.write_to_str(&resources);
     println!("{}", actual_text);

--- a/cirup_core/src/resx.rs
+++ b/cirup_core/src/resx.rs
@@ -25,19 +25,22 @@ impl FileFormat for ResxFileFormat {
     const TYPE: FormatType = FormatType::Resx;
 
     fn parse_from_str(&self, text: &str) -> Result<Vec<Resource>, Box<Error>> {
-        let bytes = without_bom(text);
-        let doc = Document::parse(bytes).unwrap();
-        let root = doc.root.unwrap();
-
         let mut resources: Vec<Resource> = Vec::new();
-        let children: Vec<&treexml::Element> = root.filter_children(|t| t.name == "data").collect();
+        let bytes = without_bom(text);
 
-        for data in children {
-            let data_name = data.attributes.get(&"name".to_owned()).unwrap();
-            let value = data.find_child(|tag| tag.name == "value").unwrap().clone();
-            let data_value = value.text.unwrap_or_default().clone();
-            let resource = Resource::new(data_name, data_value.as_ref());
-            resources.push(resource);
+        if bytes.len() > 0 {
+            let doc = Document::parse(bytes).unwrap();
+            let root = doc.root.unwrap();
+
+            let children: Vec<&treexml::Element> = root.filter_children(|t| t.name == "data").collect();
+
+            for data in children {
+                let data_name = data.attributes.get(&"name".to_owned()).unwrap();
+                let value = data.find_child(|tag| tag.name == "value").unwrap().clone();
+                let data_value = value.text.unwrap_or_default().clone();
+                let resource = Resource::new(data_name, data_value.as_ref());
+                resources.push(resource);
+            }
         }
 
         Ok(resources)

--- a/cirup_core/src/resx.rs
+++ b/cirup_core/src/resx.rs
@@ -1,26 +1,22 @@
-
 extern crate treexml;
 use treexml::{Document, Element};
 
-use Resource;
-use std::error::Error;
-use file::{FileFormat, FormatType};
 use file::{load_string_from_file, save_string_to_file};
+use file::{FileFormat, FormatType};
+use std::error::Error;
+use Resource;
 
-pub struct ResxFileFormat {
-
-}
+pub struct ResxFileFormat {}
 
 fn without_bom(text: &str) -> &[u8] {
-       if text.starts_with("\u{feff}") {
-            return &text.as_bytes()[3..];
-        }; 
+    if text.starts_with("\u{feff}") {
+        return &text.as_bytes()[3..];
+    };
 
-        return text.as_bytes();
+    return text.as_bytes();
 }
 
 impl FileFormat for ResxFileFormat {
-
     const EXTENSION: &'static str = "resx";
     const TYPE: FormatType = FormatType::Resx;
 
@@ -32,7 +28,8 @@ impl FileFormat for ResxFileFormat {
             let doc = Document::parse(bytes).unwrap();
             let root = doc.root.unwrap();
 
-            let children: Vec<&treexml::Element> = root.filter_children(|t| t.name == "data").collect();
+            let children: Vec<&treexml::Element> =
+                root.filter_children(|t| t.name == "data").collect();
 
             for data in children {
                 let data_name = data.attributes.get(&"name".to_owned()).unwrap();
@@ -56,8 +53,10 @@ impl FileFormat for ResxFileFormat {
 
         for resource in resources {
             let mut data = Element::new("data");
-            data.attributes.insert("name".to_string(), resource.name.to_string());
-            data.attributes.insert("xml:space".to_string(), "preserve".to_string());
+            data.attributes
+                .insert("name".to_string(), resource.name.to_string());
+            data.attributes
+                .insert("xml:space".to_string(), "preserve".to_string());
             let mut value = Element::new("value");
             value.text = Some(resource.value.to_string());
             data.children.push(value);
@@ -96,7 +95,7 @@ fn test_resx_parse() {
 </root>
 "#;
 
-    let file_format = ResxFileFormat { };
+    let file_format = ResxFileFormat {};
 
     let resources = file_format.parse_from_str(&text).unwrap();
 
@@ -115,8 +114,7 @@ fn test_resx_parse() {
 
 #[test]
 fn test_resx_write() {
-
-    let file_format = ResxFileFormat { };
+    let file_format = ResxFileFormat {};
 
     let resources = vec![
         Resource::new("lblBoat", "I'm on a boat."),

--- a/cirup_core/src/revision.rs
+++ b/cirup_core/src/revision.rs
@@ -1,0 +1,166 @@
+use std::error::Error;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
+pub struct RevisionRange {
+    old_rev: Option<String>,
+    new_rev: Option<String>
+}
+
+impl Default for RevisionRange {
+    fn default() -> RevisionRange {
+        RevisionRange {
+            old_rev: None,
+            new_rev: None,
+        }
+    }
+}
+
+impl PartialEq for RevisionRange {
+    fn eq(&self, other: &RevisionRange) -> bool {
+       self.old_rev == other.old_rev && self.new_rev == other.new_rev
+    }
+}
+
+impl Eq for RevisionRange { }
+
+impl RevisionRange {
+    pub fn new<S: Into<String>>(old_rev: Option<S>, new_rev: Option<S>) -> Self {
+        RevisionRange {
+            old_rev: old_rev.map(|s| s.into()),
+            new_rev: new_rev.map(|s| s.into()),
+        }
+    }
+
+    pub fn old_rev_as_ref(&self) -> Option<&str> {
+        self.old_rev.as_ref().map(String::as_str)
+    }
+
+    pub fn new_rev_as_ref(&self) -> Option<&str> {
+        self.new_rev.as_ref().map(String::as_str)
+    }
+
+    fn to_string(&self) -> String {
+        format!("{}{}", self.old_rev.as_ref().unwrap_or(&String::default()), 
+            format!("{}{}", 
+            if self.old_rev.is_some() && self.new_rev.is_some() { let x = "-"; x } else { "" },
+            self.new_rev.as_ref().unwrap_or(&String::default())))
+    }
+
+    fn from_string(string: &str) -> RevisionRange {
+        let mut revision_range = RevisionRange::default();
+        let split = string.split("-")
+            .take(2)
+            .filter(|x| !x.is_empty())
+            .collect::<Vec<_>>();
+
+        if let Some(y) = split.get(1) {
+            revision_range.new_rev = Some(y.to_string());
+
+            if let Some(x) = split.get(0) {
+                revision_range.old_rev = Some(x.to_string());
+            }
+        }
+        else if let Some(x) = split.get(0) {
+            revision_range.new_rev = Some(x.to_string());
+        }
+
+        revision_range
+    }
+
+    pub fn append_to_file_name(&self, path: PathBuf) -> Result<PathBuf, Box<Error>> {
+        let rev = format!("~{}~", self.to_string());
+        let file_stem = path.file_stem().unwrap_or(OsStr::new(""));
+        let mut file_name = file_stem.to_os_string();
+
+        if !rev.is_empty() {
+            file_name.push(format!(".{}", rev));
+        }
+
+        if let Some(extension) = path.extension() {
+            file_name.push(".");
+            file_name.push(extension)
+        }
+
+        Ok(path.with_file_name(file_name))
+    }
+
+    pub fn extract_from_file_name(path: PathBuf) -> (RevisionRange, PathBuf) {
+        let mut revision_range = RevisionRange { old_rev: None, new_rev: None };
+        let file_stem = path.file_stem().unwrap_or(OsStr::new(""));
+        let file_name = file_stem.to_string_lossy();
+        let mut split = file_name.split(".")
+            .filter(|x| !x.is_empty())
+            .collect::<Vec<_>>();
+
+        if split.len() > 1 {
+            let revision = split.pop().unwrap();
+
+            if revision.starts_with('~') && revision.ends_with('~') {
+                let trimmed = revision.trim_matches('~');
+                revision_range = RevisionRange::from_string(trimmed);
+            } else {
+                split.push(revision);
+            }
+        }
+
+        let mut file_name = split.join(".").to_string();
+
+        if let Some(extension) = path.extension() {
+            file_name.push_str(".");
+            file_name.push_str(&extension.to_string_lossy());
+        }
+
+        (revision_range, path.with_file_name(file_name))
+    }
+}
+
+
+#[test]
+fn revision_range_to_string_test() {
+    let mut a = RevisionRange { old_rev: Some("r123".to_string()), new_rev: Some("r456".to_string()) };
+    assert_eq!(a.to_string(), "r123-r456");
+    a = RevisionRange { old_rev: Some("r123".to_string()), new_rev: None };
+    assert_eq!(a.to_string(), "r123");
+    a = RevisionRange { old_rev: Some("r456".to_string()), new_rev: None };
+    assert_eq!(a.to_string(), "r456");
+    a = RevisionRange { old_rev: None, new_rev: None };
+    assert_eq!(a.to_string(), "");
+}
+
+#[test]
+fn revision_range_from_string_test() {
+    let mut a = RevisionRange::from_string("r123-r456");
+    assert_eq!(a.old_rev, Some("r123".to_string()));
+    assert_eq!(a.new_rev, Some("r456".to_string()));
+    a = RevisionRange::from_string("r123");
+    assert_eq!(a.old_rev, None);
+    assert_eq!(a.new_rev, Some("r123".to_string()));
+    a = RevisionRange::from_string("");
+    assert_eq!(a.old_rev, None);
+    assert_eq!(a.new_rev, None);
+    a = RevisionRange::from_string("-");
+    assert_eq!(a.old_rev, None);
+    assert_eq!(a.new_rev, None);
+}
+
+#[test]
+fn revision_range_append_to_file_name_test() {
+    let mut p = PathBuf::from("/test/path/myfile.resx");
+    let rev = RevisionRange { old_rev: Some("r123".to_string()), new_rev: Some("r456".to_string()) };
+    p = rev.append_to_file_name(p).unwrap();
+    assert_eq!(p, PathBuf::from("/test/path/myfile.~r123-r456~.resx"));
+}
+
+    #[test]
+
+fn revision_range_extract_from_file_name_test() {
+    let (revision, path) = RevisionRange::extract_from_file_name(PathBuf::from("/test/path/myfile.~r123-r456~.resx"));
+    assert_eq!(revision.old_rev, Some("r123".to_string()));
+    assert_eq!(revision.new_rev, Some("r456".to_string()));
+    assert_eq!(path, PathBuf::from("/test/path/myfile.resx"));
+    let (revision, path) = RevisionRange::extract_from_file_name(PathBuf::from("/test/path/myfile.not.a.revision.resx"));
+    assert_eq!(revision.old_rev, None);
+    assert_eq!(revision.new_rev, None);
+    assert_eq!(path, PathBuf::from("/test/path/myfile.not.a.revision.resx"));
+}

--- a/cirup_core/src/revision.rs
+++ b/cirup_core/src/revision.rs
@@ -1,10 +1,11 @@
 use std::error::Error;
 use std::ffi::OsStr;
+use std::fmt;
 use std::path::PathBuf;
 
 pub struct RevisionRange {
-    old_rev: Option<String>,
-    new_rev: Option<String>
+    pub old_rev: Option<String>,
+    pub new_rev: Option<String>
 }
 
 impl Default for RevisionRange {
@@ -23,6 +24,12 @@ impl PartialEq for RevisionRange {
 }
 
 impl Eq for RevisionRange { }
+
+impl fmt::Display for RevisionRange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}
 
 impl RevisionRange {
     pub fn new<S: Into<String>>(old_rev: Option<S>, new_rev: Option<S>) -> Self {

--- a/cirup_core/src/revision.rs
+++ b/cirup_core/src/revision.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 pub struct RevisionRange {
     pub old_rev: Option<String>,
-    pub new_rev: Option<String>
+    pub new_rev: Option<String>,
 }
 
 impl Default for RevisionRange {
@@ -19,11 +19,11 @@ impl Default for RevisionRange {
 
 impl PartialEq for RevisionRange {
     fn eq(&self, other: &RevisionRange) -> bool {
-       self.old_rev == other.old_rev && self.new_rev == other.new_rev
+        self.old_rev == other.old_rev && self.new_rev == other.new_rev
     }
 }
 
-impl Eq for RevisionRange { }
+impl Eq for RevisionRange {}
 
 impl fmt::Display for RevisionRange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -48,15 +48,26 @@ impl RevisionRange {
     }
 
     fn to_string(&self) -> String {
-        format!("{}{}", self.old_rev.as_ref().unwrap_or(&String::default()), 
-            format!("{}{}", 
-            if self.old_rev.is_some() && self.new_rev.is_some() { let x = "-"; x } else { "" },
-            self.new_rev.as_ref().unwrap_or(&String::default())))
+        format!(
+            "{}{}",
+            self.old_rev.as_ref().unwrap_or(&String::default()),
+            format!(
+                "{}{}",
+                if self.old_rev.is_some() && self.new_rev.is_some() {
+                    let x = "-";
+                    x
+                } else {
+                    ""
+                },
+                self.new_rev.as_ref().unwrap_or(&String::default())
+            )
+        )
     }
 
     fn from_string(string: &str) -> RevisionRange {
         let mut revision_range = RevisionRange::default();
-        let split = string.split("-")
+        let split = string
+            .split("-")
             .take(2)
             .filter(|x| !x.is_empty())
             .collect::<Vec<_>>();
@@ -67,8 +78,7 @@ impl RevisionRange {
             if let Some(x) = split.get(0) {
                 revision_range.old_rev = Some(x.to_string());
             }
-        }
-        else if let Some(x) = split.get(0) {
+        } else if let Some(x) = split.get(0) {
             revision_range.new_rev = Some(x.to_string());
         }
 
@@ -93,10 +103,14 @@ impl RevisionRange {
     }
 
     pub fn extract_from_file_name(path: PathBuf) -> (RevisionRange, PathBuf) {
-        let mut revision_range = RevisionRange { old_rev: None, new_rev: None };
+        let mut revision_range = RevisionRange {
+            old_rev: None,
+            new_rev: None,
+        };
         let file_stem = path.file_stem().unwrap_or(OsStr::new(""));
         let file_name = file_stem.to_string_lossy();
-        let mut split = file_name.split(".")
+        let mut split = file_name
+            .split(".")
             .filter(|x| !x.is_empty())
             .collect::<Vec<_>>();
 
@@ -122,16 +136,27 @@ impl RevisionRange {
     }
 }
 
-
 #[test]
 fn revision_range_to_string_test() {
-    let mut a = RevisionRange { old_rev: Some("r123".to_string()), new_rev: Some("r456".to_string()) };
+    let mut a = RevisionRange {
+        old_rev: Some("r123".to_string()),
+        new_rev: Some("r456".to_string()),
+    };
     assert_eq!(a.to_string(), "r123-r456");
-    a = RevisionRange { old_rev: Some("r123".to_string()), new_rev: None };
+    a = RevisionRange {
+        old_rev: Some("r123".to_string()),
+        new_rev: None,
+    };
     assert_eq!(a.to_string(), "r123");
-    a = RevisionRange { old_rev: Some("r456".to_string()), new_rev: None };
+    a = RevisionRange {
+        old_rev: Some("r456".to_string()),
+        new_rev: None,
+    };
     assert_eq!(a.to_string(), "r456");
-    a = RevisionRange { old_rev: None, new_rev: None };
+    a = RevisionRange {
+        old_rev: None,
+        new_rev: None,
+    };
     assert_eq!(a.to_string(), "");
 }
 
@@ -154,19 +179,25 @@ fn revision_range_from_string_test() {
 #[test]
 fn revision_range_append_to_file_name_test() {
     let mut p = PathBuf::from("/test/path/myfile.resx");
-    let rev = RevisionRange { old_rev: Some("r123".to_string()), new_rev: Some("r456".to_string()) };
+    let rev = RevisionRange {
+        old_rev: Some("r123".to_string()),
+        new_rev: Some("r456".to_string()),
+    };
     p = rev.append_to_file_name(p).unwrap();
     assert_eq!(p, PathBuf::from("/test/path/myfile.~r123-r456~.resx"));
 }
 
-    #[test]
+#[test]
 
 fn revision_range_extract_from_file_name_test() {
-    let (revision, path) = RevisionRange::extract_from_file_name(PathBuf::from("/test/path/myfile.~r123-r456~.resx"));
+    let (revision, path) =
+        RevisionRange::extract_from_file_name(PathBuf::from("/test/path/myfile.~r123-r456~.resx"));
     assert_eq!(revision.old_rev, Some("r123".to_string()));
     assert_eq!(revision.new_rev, Some("r456".to_string()));
     assert_eq!(path, PathBuf::from("/test/path/myfile.resx"));
-    let (revision, path) = RevisionRange::extract_from_file_name(PathBuf::from("/test/path/myfile.not.a.revision.resx"));
+    let (revision, path) = RevisionRange::extract_from_file_name(PathBuf::from(
+        "/test/path/myfile.not.a.revision.resx",
+    ));
     assert_eq!(revision.old_rev, None);
     assert_eq!(revision.new_rev, None);
     assert_eq!(path, PathBuf::from("/test/path/myfile.not.a.revision.resx"));

--- a/cirup_core/src/shell.rs
+++ b/cirup_core/src/shell.rs
@@ -23,24 +23,18 @@ pub fn status(exe: &str, dir: &Path, args: &[&str]) -> Result<i32, Box<Error>> {
 
     match status.code() {
         Some(c) => Ok(c),
-        None => Err("process terminated by signal")?
+        None => Err("process terminated by signal")?,
     }
 }
 
 pub fn output(exe: &str, dir: &Path, args: &[&str]) -> Result<String, Box<Error>> {
-    let output = Command::new(exe)
-        .current_dir(dir)
-        .args(args)
-        .output()?;
+    let output = Command::new(exe).current_dir(dir).args(args).output()?;
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 pub fn output_to_file(exe: &str, dir: &Path, args: &[&str], out: &Path) -> Result<(), Box<Error>> {
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(out)?;
+    let mut file = OpenOptions::new().write(true).create(true).open(out)?;
 
     let output = output(exe, dir, args)?;
 
@@ -52,7 +46,10 @@ pub fn output_to_file(exe: &str, dir: &Path, args: &[&str], out: &Path) -> Resul
 pub fn find_binary(binary: &str) -> Option<::std::path::PathBuf> {
     if let Ok(output) = Command::new(LOCATE_COMMAND).arg(binary).output() {
         let bin = str::from_utf8(&output.stdout)
-            .expect(&format!("non-UTF8 output when running `{} {}`", LOCATE_COMMAND, binary))
+            .expect(&format!(
+                "non-UTF8 output when running `{} {}`",
+                LOCATE_COMMAND, binary
+            ))
             .trim()
             .lines()
             .next()
@@ -80,7 +77,7 @@ fn binary_ran_ok<S: AsRef<OsStr>>(path: S) -> bool {
 fn shell_status() {
     // TODO This test is not cross-platform
     let dir = Path::new(".");
-    let status = status("ls", &dir, &[ "-l" ]);
+    let status = status("ls", &dir, &["-l"]);
     assert!(status.is_ok())
 }
 

--- a/cirup_core/src/shell.rs
+++ b/cirup_core/src/shell.rs
@@ -14,6 +14,7 @@ const LOCATE_COMMAND: &'static str = "where";
 const LOCATE_COMMAND: &'static str = "which";
 
 pub fn status(exe: &str, dir: &Path, args: &[&str]) -> Result<i32, Box<Error>> {
+    trace!("{} {:?}", exe, args);
     let status = Command::new(exe)
         .current_dir(dir)
         .args(args)
@@ -28,6 +29,7 @@ pub fn status(exe: &str, dir: &Path, args: &[&str]) -> Result<i32, Box<Error>> {
 }
 
 pub fn output(exe: &str, dir: &Path, args: &[&str]) -> Result<String, Box<Error>> {
+    trace!("{} {:?}", exe, args);
     let output = Command::new(exe).current_dir(dir).args(args).output()?;
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())

--- a/cirup_core/src/shell.rs
+++ b/cirup_core/src/shell.rs
@@ -17,6 +17,8 @@ pub fn status(exe: &str, dir: &Path, args: &[&str]) -> Result<i32, Box<Error>> {
     let status = Command::new(exe)
         .current_dir(dir)
         .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status()?;
 
     match status.code() {

--- a/cirup_core/src/sync.rs
+++ b/cirup_core/src/sync.rs
@@ -12,9 +12,9 @@ use tempfile;
 use config::Config;
 use query;
 use revision::RevisionRange;
+use utils::*;
 use vcs;
 use vcs::Vcs;
-use utils::*;
 
 pub struct Sync {
     pub vcs: Box<Vcs>,
@@ -24,7 +24,7 @@ pub struct Sync {
     working_dir: String,
     match_rex: Regex,
     lang_rex: Regex,
-    temp_dir: tempfile::TempDir
+    temp_dir: tempfile::TempDir,
 }
 
 struct LanguageFile {
@@ -54,34 +54,35 @@ impl LanguageFile {
 
         let file_ext = match path_ref.extension().and_then(OsStr::to_str) {
             Some(extension) => extension.to_string(),
-            _ => Err(format!("invalid language file {:?}", path_ref))?
+            _ => Err(format!("invalid language file {:?}", path_ref))?,
         };
-        let (language_revision, path) = RevisionRange::extract_from_file_name(PathBuf::from(path.as_ref()));
+        let (language_revision, path) =
+            RevisionRange::extract_from_file_name(PathBuf::from(path.as_ref()));
         let file_name = match path.file_name().and_then(OsStr::to_str) {
             Some(file_name) => file_name.to_string(),
-            _ => Err(format!("invalid language file {:?}", path_ref))?
+            _ => Err(format!("invalid language file {:?}", path_ref))?,
         };
 
         Ok(LanguageFile {
             path: path_ref,
             file_name: file_name,
             _file_ext: file_ext,
-            revision: language_revision
+            revision: language_revision,
         })
     }
 }
 
 fn find_languages(
-    source_dir: &PathBuf, 
-    match_regex: &Regex, 
-    lang_regex: &Regex) 
-    -> Result<HashMap<String, LanguageFile>, Box<Error>> {
+    source_dir: &PathBuf,
+    match_regex: &Regex,
+    lang_regex: &Regex,
+) -> Result<HashMap<String, LanguageFile>, Box<Error>> {
     let mut languages: HashMap<String, LanguageFile> = HashMap::new();
 
     for entry in fs::read_dir(&source_dir)? {
         if let Ok(language_file) = LanguageFile::load(entry.unwrap().path()) {
             if !match_regex.is_match(&language_file.file_name) {
-                continue
+                continue;
             }
 
             if let Some(captures) = lang_regex.captures(&language_file.file_name.to_string()) {
@@ -98,11 +99,13 @@ impl Sync {
         let vcs = vcs::new(config)?;
         vcs.pull()?;
 
-        let source_dir = Path::new(&config.vcs.local_path)
-            .join(config.sync.source_dir.to_string());
+        let source_dir = Path::new(&config.vcs.local_path).join(config.sync.source_dir.to_string());
 
         if !source_dir.is_dir() {
-            Err(format!("source_dir {:?} does not exist or not a directory", &source_dir))?;
+            Err(format!(
+                "source_dir {:?} does not exist or not a directory",
+                &source_dir
+            ))?;
         }
 
         let working_dir = Path::new(&config.sync.working_dir);
@@ -117,15 +120,21 @@ impl Sync {
         let mut languages = find_languages(&source_dir, &match_rex, &lang_rex)?;
 
         if languages.is_empty() {
-            Err(format!("couldn't find any language files in {:?}", &source_dir))?;
+            Err(format!(
+                "couldn't find any language files in {:?}",
+                &source_dir
+            ))?;
         }
 
         languages.retain(|key, _value| {
             key == &config.sync.source_language || config.sync.target_languages.contains(key)
         });
-        
+
         if !languages.contains_key(&config.sync.source_language) {
-            Err(format!("couldn't find source language file in {:?}", &source_dir))?;
+            Err(format!(
+                "couldn't find source language file in {:?}",
+                &source_dir
+            ))?;
         }
 
         let sync = Sync {
@@ -148,42 +157,66 @@ impl Sync {
 
     fn source_language(&self) -> Option<&LanguageFile> {
         self.languages.get(&self.source_language)
-    } 
+    }
 
     pub fn source_language_path(&self) -> PathBuf {
         if let Some(language) = self.source_language() {
             return language.path.to_owned();
         }
-        
-        PathBuf::default()
-    } 
 
-    fn create_source_language_file(&self, rev: &RevisionRange, show_changes: bool) -> Result<PathBuf, Box<Error>> {
+        PathBuf::default()
+    }
+
+    fn create_source_language_file(
+        &self,
+        rev: &RevisionRange,
+        show_changes: bool,
+    ) -> Result<PathBuf, Box<Error>> {
         debug!("preparing source file for revision(s) {}", rev);
         let source = self.source_language().unwrap();
         let source_path_vcs = self.vcs_relative_path(&source.file_name);
-        let source_path_out = rev.append_to_file_name(Path::new(&self.working_dir).join(&source.file_name))?;
+        let source_path_out =
+            rev.append_to_file_name(Path::new(&self.working_dir).join(&source.file_name))?;
 
         let old_commit = rev.old_rev_as_ref();
         let new_commit = rev.old_rev_as_ref();
 
         if rev.old_rev.is_none() {
-            self.vcs.show(&source_path_vcs.to_string_lossy(), None, &source_path_out.to_string_lossy())?;
+            self.vcs.show(
+                &source_path_vcs.to_string_lossy(),
+                None,
+                &source_path_out.to_string_lossy(),
+            )?;
         } else {
             let rev_old = RevisionRange::new(old_commit, None);
-            let old_path = rev_old.append_to_file_name(Path::new(self.temp_dir.path()).join(&source.file_name))?;
-            self.vcs.show(&source_path_vcs.to_string_lossy(), old_commit, &old_path.to_string_lossy())?;
+            let old_path = rev_old
+                .append_to_file_name(Path::new(self.temp_dir.path()).join(&source.file_name))?;
+            self.vcs.show(
+                &source_path_vcs.to_string_lossy(),
+                old_commit,
+                &old_path.to_string_lossy(),
+            )?;
 
             let rev_new = RevisionRange::new(None, new_commit);
-            let new_path = rev_new.append_to_file_name(Path::new(self.temp_dir.path()).join(&source.file_name))?;
-            self.vcs.show(&source_path_vcs.to_string_lossy(), new_commit, &new_path.to_string_lossy())?;
+            let new_path = rev_new
+                .append_to_file_name(Path::new(self.temp_dir.path()).join(&source.file_name))?;
+            self.vcs.show(
+                &source_path_vcs.to_string_lossy(),
+                new_commit,
+                &new_path.to_string_lossy(),
+            )?;
 
-            debug!("generating source file from {} and {}", old_path.display(), new_path.display());
+            debug!(
+                "generating source file from {} and {}",
+                old_path.display(),
+                new_path.display()
+            );
 
-            let query : query::CirupQuery;
+            let query: query::CirupQuery;
 
             if show_changes {
-                query = query::query_change(&new_path.to_string_lossy(), &old_path.to_string_lossy());
+                query =
+                    query::query_change(&new_path.to_string_lossy(), &old_path.to_string_lossy());
             } else {
                 query = query::query_diff(&new_path.to_string_lossy(), &old_path.to_string_lossy());
             }
@@ -197,23 +230,31 @@ impl Sync {
     }
 
     pub fn push(
-        &self, 
-        old_commit: Option<&str>, 
-        new_commit: Option<&str>) 
-        -> Result<(), Box<Error>> {
+        &self,
+        old_commit: Option<&str>,
+        new_commit: Option<&str>,
+    ) -> Result<(), Box<Error>> {
         let current_rev = sanitized(&self.vcs.current_revision()?).to_string();
-        let rev = RevisionRange::new(old_commit, match new_commit {
-           Some(new_commit) => Some(new_commit),
-           None => Some(&current_rev)
-        });
+        let rev = RevisionRange::new(
+            old_commit,
+            match new_commit {
+                Some(new_commit) => Some(new_commit),
+                None => Some(&current_rev),
+            },
+        );
         let source_path_out = self.create_source_language_file(&rev, true)?;
-       
-        let mut translations = find_languages(&Path::new(&self.working_dir).to_path_buf(), &self.match_rex, &self.lang_rex)?;
-        translations.retain(|_key, value| {
-            value.revision == rev
-        });
+
+        let mut translations = find_languages(
+            &Path::new(&self.working_dir).to_path_buf(),
+            &self.match_rex,
+            &self.lang_rex,
+        )?;
+        translations.retain(|_key, value| value.revision == rev);
         if translations.is_empty() {
-            Err(format!("no pending translations for revision(s) {} in {}", rev, &self.working_dir))?;
+            Err(format!(
+                "no pending translations for revision(s) {} in {}",
+                rev, &self.working_dir
+            ))?;
         }
 
         for (language, language_file) in &translations {
@@ -226,22 +267,44 @@ impl Sync {
                     FROM B
                     INNER JOIN A on (A.key = B.key) AND (A.val <> B.val)";
 
-                let query = query::CirupQuery::new(query_string, &source_path_out.to_string_lossy(), Some(&language_file.path.to_string_lossy()));
-                let file_path = rev.append_to_file_name(Path::new(self.temp_dir.path()).join(&language_file.file_name))?;
+                let query = query::CirupQuery::new(
+                    query_string,
+                    &source_path_out.to_string_lossy(),
+                    Some(&language_file.path.to_string_lossy()),
+                );
+                let file_path = rev.append_to_file_name(
+                    Path::new(self.temp_dir.path()).join(&language_file.file_name),
+                )?;
 
-                debug!("generating intermediate file from {} and {}", source_path_out.display(), language_file.path.display());
+                debug!(
+                    "generating intermediate file from {} and {}",
+                    source_path_out.display(),
+                    language_file.path.display()
+                );
                 query.run_interactive(Some(&file_path.to_string_lossy()));
 
                 match self.languages.get(language) {
                     Some(vcs_language_file) => {
-                        debug!("merging {} into {}", language_file.path.display(), vcs_language_file.path.display());
-                        let query = query::query_merge(&vcs_language_file.path.to_string_lossy(), &file_path.to_string_lossy());
+                        debug!(
+                            "merging {} into {}",
+                            language_file.path.display(),
+                            vcs_language_file.path.display()
+                        );
+                        let query = query::query_merge(
+                            &vcs_language_file.path.to_string_lossy(),
+                            &file_path.to_string_lossy(),
+                        );
                         query.run_interactive(Some(&vcs_language_file.path.to_string_lossy()));
-                        info!("merged translation for {} from {} into {}", language, language_file.path.display(), vcs_language_file.path.display());
-                    },
+                        info!(
+                            "merged translation for {} from {} into {}",
+                            language,
+                            language_file.path.display(),
+                            vcs_language_file.path.display()
+                        );
+                    }
                     None => {
                         warn!("no source language for {} in version control!", language);
-                    },
+                    }
                 }
             }
         }
@@ -249,59 +312,79 @@ impl Sync {
         Ok(())
     }
 
-/*
-If no old commit is specified:
-    diff the source language with the other languages
-    generate an output file for every target language, with the missing translations
-If an old commit is specified:
-    new commit defaults to HEAD
-    diff the changes between the old and new version of the source language
-    generate an output file for every target language, with missing missing translations
-    (and, optionally, changed translations)
-*/
+    /*
+    If no old commit is specified:
+        diff the source language with the other languages
+        generate an output file for every target language, with the missing translations
+    If an old commit is specified:
+        new commit defaults to HEAD
+        diff the changes between the old and new version of the source language
+        generate an output file for every target language, with missing missing translations
+        (and, optionally, changed translations)
+    */
     pub fn pull(
-        &self, 
-        old_commit: Option<&str>, 
+        &self,
+        old_commit: Option<&str>,
         new_commit: Option<&str>,
-        show_changes: bool) -> Result<(), Box<Error>> {
+        show_changes: bool,
+    ) -> Result<(), Box<Error>> {
         let current_rev = sanitized(&self.vcs.current_revision()?);
-        let rev = RevisionRange::new(old_commit, match new_commit {
-           Some(new_commit) => Some(new_commit),
-           None => Some(&current_rev)
-        });
+        let rev = RevisionRange::new(
+            old_commit,
+            match new_commit {
+                Some(new_commit) => Some(new_commit),
+                None => Some(&current_rev),
+            },
+        );
         let source_path_out = self.create_source_language_file(&rev, show_changes)?;
 
         for (language, language_file) in &self.languages {
             if language == &self.source_language {
-                continue
+                continue;
             }
 
             debug!("generating translation for {}", language);
 
             let target_path_vcs = self.vcs_relative_path(&language_file.file_name);
-            let target_path_out = rev.append_to_file_name(Path::new(&self.working_dir).join(&language_file.file_name))?;
+            let target_path_out = rev
+                .append_to_file_name(Path::new(&self.working_dir).join(&language_file.file_name))?;
 
-            let file_path = RevisionRange::new(None, rev.new_rev_as_ref())
-                .append_to_file_name(Path::new(self.temp_dir.path()).
-                    join(&language_file.file_name))?;
-            self.vcs.show(&target_path_vcs.to_string_lossy(), new_commit, &file_path.to_string_lossy())?;
+            let file_path = RevisionRange::new(None, rev.new_rev_as_ref()).append_to_file_name(
+                Path::new(self.temp_dir.path()).join(&language_file.file_name),
+            )?;
+            self.vcs.show(
+                &target_path_vcs.to_string_lossy(),
+                new_commit,
+                &file_path.to_string_lossy(),
+            )?;
 
-            let query : query::CirupQuery;
-            
+            let query: query::CirupQuery;
+
             if old_commit.is_none() {
-                query = query::query_diff(&source_path_out.to_string_lossy(), &file_path.to_string_lossy());
+                query = query::query_diff(
+                    &source_path_out.to_string_lossy(),
+                    &file_path.to_string_lossy(),
+                );
             } else {
                 let query_string = r"
                     SELECT
                         A.key, A.val
                     FROM A
                     LEFT OUTER JOIN B on A.key = B.key";
-                query = query::CirupQuery::new(query_string, &source_path_out.to_string_lossy(), Some(&file_path.to_string_lossy()));
+                query = query::CirupQuery::new(
+                    query_string,
+                    &source_path_out.to_string_lossy(),
+                    Some(&file_path.to_string_lossy()),
+                );
             }
-            
+
             query.run_interactive(Some(&target_path_out.to_string_lossy()));
 
-            info!("generated translation for {} in {}", language, target_path_out.display());
+            info!(
+                "generated translation for {} in {}",
+                language,
+                target_path_out.display()
+            );
         }
 
         Ok(())

--- a/cirup_core/src/sync.rs
+++ b/cirup_core/src/sync.rs
@@ -175,7 +175,6 @@ If an old commit is specified:
         old_commit: Option<&str>, 
         new_commit: Option<&str>) 
         -> Result<(), Box<Error>> {
-        println!("starting pull...");
 
         let source_language_path = self.source_language_path();
         let source_language_filename = source_language_path.file_name().unwrap();
@@ -210,8 +209,6 @@ If an old commit is specified:
                 continue
             }
 
-            println!("processing translation: {}", language);
-
             let file_name = format!("{}.{}",
                 if new_commit.is_some() { new_commit.unwrap() } else { "HEAD"},
                 path.file_name().unwrap().to_string_lossy());
@@ -239,12 +236,10 @@ If an old commit is specified:
                 query = query::CirupQuery::new(query_string, &out_path.to_string_lossy(), Some(&file_path.to_string_lossy()));
             }
             
-            println!("creating translation in {:?}", target_out_path);
-
             query.run_interactive(Some(&target_out_path.to_string_lossy()));
-        }
 
-        println!("pull complete");
+            info!("translation file generated: {:?}", target_out_path);
+        }
 
         Ok(())
     }

--- a/cirup_core/src/sync.rs
+++ b/cirup_core/src/sync.rs
@@ -13,10 +13,11 @@ use config::Config;
 use query;
 use vcs;
 use vcs::Vcs;
+use utils::*;
 
 pub struct Sync {
     pub vcs: Box<Vcs>,
-    languages: HashMap<String, PathBuf>,
+    languages: HashMap<String, LanguageFile>,
     source_language: String,
     source_path: String,
     working_dir: String,
@@ -24,25 +25,180 @@ pub struct Sync {
     lang_rex: Regex,
 }
 
+struct LanguageRevision {
+    old_rev: Option<String>,
+    new_rev: Option<String>
+}
+
+impl Default for LanguageRevision {
+    fn default() -> LanguageRevision {
+        LanguageRevision {
+            old_rev: None,
+            new_rev: None,
+        }
+    }
+}
+
+impl PartialEq for LanguageRevision {
+    fn eq(&self, other: &LanguageRevision) -> bool {
+       self.old_rev == other.old_rev && self.new_rev == other.new_rev
+    }
+}
+
+impl Eq for LanguageRevision { }
+
+impl LanguageRevision {
+    fn new<S: Into<String>>(old_rev: Option<S>, new_rev: Option<S>) -> Self {
+        LanguageRevision {
+            old_rev: old_rev.map(|s| s.into()),
+            new_rev: new_rev.map(|s| s.into()),
+        }
+    }
+
+    fn old_rev_as_ref(&self) -> Option<&str> {
+        self.old_rev.as_ref().map(String::as_str)
+    }
+
+    fn new_rev_as_ref(&self) -> Option<&str> {
+        self.new_rev.as_ref().map(String::as_str)
+    }
+
+    fn to_string(&self) -> String {
+        format!("~{}{}~", self.old_rev.as_ref().unwrap_or(&String::default()), 
+            format!("{}{}", 
+            if self.old_rev.is_some() && self.new_rev.is_some() { let x = "-"; x } else { "" },
+            self.new_rev.as_ref().unwrap_or(&String::default())))
+    }
+
+    fn from_string(string: &str) -> LanguageRevision {
+        let mut language_revision = LanguageRevision::default();
+        let split = string.split("-")
+            .take(2)
+            .filter(|x| !x.is_empty())
+            .collect::<Vec<_>>();
+
+        if let Some(y) = split.get(1) {
+            language_revision.new_rev = Some(y.to_string());
+
+            if let Some(x) = split.get(0) {
+                language_revision.old_rev = Some(x.to_string());
+            }
+        }
+        else if let Some(x) = split.get(0) {
+            language_revision.new_rev = Some(x.to_string());
+        }
+
+        language_revision
+    }
+
+    fn append_to_file_name(&self, path: PathBuf) -> Result<PathBuf, Box<Error>> {
+        let rev : String = self.to_string();
+        let file_stem = path.file_stem().unwrap_or(OsStr::new(""));
+        let mut file_name = file_stem.to_os_string();
+
+        if !rev.is_empty() {
+            file_name.push(format!(".{}", rev));
+        }
+
+        if let Some(extension) = path.extension() {
+            file_name.push(".");
+            file_name.push(extension)
+        }
+
+        Ok(path.with_file_name(file_name))
+    }
+
+    fn extract_from_file_name(path: PathBuf) -> (LanguageRevision, PathBuf) {
+        let mut language_revision = LanguageRevision { old_rev: None, new_rev: None };
+        let file_stem = path.file_stem().unwrap_or(OsStr::new(""));
+        let file_name = file_stem.to_string_lossy();
+        let mut split = file_name.split(".")
+            .filter(|x| !x.is_empty())
+            .collect::<Vec<_>>();
+
+        if split.len() > 1 {
+            let revision = split.pop().unwrap();
+
+            if revision.starts_with('~') && revision.ends_with('~') {
+                let trimmed = revision.trim_matches('~');
+                language_revision = LanguageRevision::from_string(trimmed);
+            } else {
+                split.push(revision);
+            }
+        }
+
+        let mut file_name = split.join(".").to_string();
+
+        if let Some(extension) = path.extension() {
+            file_name.push_str(".");
+            file_name.push_str(&extension.to_string_lossy());
+        }
+
+        (language_revision, path.with_file_name(file_name))
+    }
+}
+
+struct LanguageFile {
+    path: PathBuf,
+    file_name: String,
+    file_ext: String,
+    revision: LanguageRevision,
+}
+
+impl Default for LanguageFile {
+    fn default() -> LanguageFile {
+        LanguageFile {
+            path: PathBuf::default(),
+            file_name: String::new(),
+            file_ext: String::new(),
+            revision: LanguageRevision::default(),
+        }
+    }
+}
+
+impl LanguageFile {
+    fn load<T: AsRef<Path>>(path: T) -> Result<LanguageFile, Box<Error>> {
+        let path_ref = PathBuf::from(path.as_ref());
+        if !path_ref.is_file() {
+            Err("invalid language file")?;
+        };
+
+        let file_ext = match path_ref.extension().and_then(OsStr::to_str) {
+            Some(extension) => extension.to_string(),
+            _ => Err(format!("invalid language file {:?}", path_ref))?
+        };
+        let (language_revision, path) = LanguageRevision::extract_from_file_name(PathBuf::from(path.as_ref()));
+        let file_name = match path.file_name().and_then(OsStr::to_str) {
+            Some(file_name) => file_name.to_string(),
+            _ => Err(format!("invalid language file {:?}", path_ref))?
+        };
+
+        Ok(LanguageFile {
+            path: path_ref,
+            file_name: file_name,
+            file_ext: file_ext,
+            revision: language_revision
+        })
+    }
+}
+
 fn find_languages(
     source_dir: &PathBuf, 
     match_regex: &Regex, 
     lang_regex: &Regex) 
-    -> Result<HashMap<String, PathBuf>, Box<Error>> {
-    let mut languages: HashMap<String, PathBuf> = HashMap::new();
+    -> Result<HashMap<String, LanguageFile>, Box<Error>> {
+    let mut languages: HashMap<String, LanguageFile> = HashMap::new();
 
     for entry in fs::read_dir(&source_dir)? {
-            let path = entry.unwrap().path();
-            let file_name = path.file_name().unwrap();
-            let file_name_as_str = file_name.to_str().unwrap();
-
-            if match_regex.is_match(file_name_as_str) {
-                let lang = lang_regex.captures(file_name_as_str);
-
-                if lang.is_some() {
-                    languages.insert(lang.unwrap()[1].to_string(), path.to_path_buf());
-                }
+        if let Ok(language_file) = LanguageFile::load(entry.unwrap().path()) {
+            if !match_regex.is_match(&language_file.file_name) {
+                continue
             }
+
+            if let Some(captures) = lang_regex.captures(&language_file.file_name.to_string()) {
+                languages.insert(captures[1].to_string(), language_file);
+            }
+        }
     }
 
     Ok(languages)
@@ -96,29 +252,47 @@ impl Sync {
         Ok(sync)
     }
 
-    fn vcs_relative_path(&self, file_name: &OsStr) -> PathBuf {
+    fn vcs_relative_path<P: AsRef<Path>>(&self, file_name: P) -> PathBuf {
         Path::new(&self.source_path).join(file_name)
     }
 
-    pub fn source_language_path(&self) -> &PathBuf {
-        self.languages.get(&self.source_language).unwrap()
+    fn source_language(&self) -> Option<&LanguageFile> {
+        self.languages.get(&self.source_language)
     } 
 
-    pub fn push(&self, force: bool) -> Result<(), Box<Error>> {
-        println!("starting push...");
+    pub fn source_language_path(&self) -> PathBuf {
+        if let Some(language) = self.source_language() {
+            return language.path.to_owned();
+        }
+        
+        PathBuf::default()
+    } 
 
-        let source_language_path = self.source_language_path();
-        let source_language_filename = source_language_path.file_name().unwrap();
-        let source_path = self.vcs_relative_path(source_language_filename);
-        let out_path = Path::new(&self.working_dir).join(source_language_filename);
+    pub fn push(
+        &self, 
+        old_commit: Option<&str>, 
+        new_commit: Option<&str>) 
+        -> Result<(), Box<Error>> {
+        let temp_dir = tempdir()?;
+        let current_rev = sanitized(&self.vcs.current_revision()?).to_string();
+        let rev = LanguageRevision::new(old_commit, match new_commit {
+           Some(new_commit) => Some(new_commit),
+           None => Some(&current_rev)
+        });
+        let source_language_file = self.source_language().unwrap();
+        // let source_language_filename = &source_language_file.file_name;
+        // let source_path = self.vcs_relative_path(source_language_filename);
+        // let out_path = Path::new(&self.working_dir).join(source_language_filename);
 
         // Grab the HEAD source language for validation
-        self.vcs.show(&source_path.to_string_lossy(), None, &out_path.to_string_lossy())?;
+        //self.vcs.show(&source_path.to_string_lossy(), None, &out_path.to_string_lossy())?;
 
-        println!("looking for translations in {}", &self.working_dir);
-
-        let translations = find_languages(&Path::new(&self.working_dir).to_path_buf(), 
+        let mut translations = find_languages(&Path::new(&self.working_dir).to_path_buf(), 
             &self.match_rex, &self.lang_rex)?;
+
+        translations.retain(|_key, value| {
+            value.revision == rev
+        });
 
         if translations.is_empty() {
             Err(format!("working_dir {:?} doesn't contain any translations", &self.working_dir))?;
@@ -126,33 +300,69 @@ impl Sync {
 
         println!("found {} translations", translations.keys().count());
 
-        for (language, path) in &translations {
+//
+        let source = self.source_language().unwrap();
+        let source_path_vcs = self.vcs_relative_path(&source.file_name);
+        let source_path_out = rev.append_to_file_name(Path::new(temp_dir.path()).join(&source.file_name))?;
+
+        let rev_old = LanguageRevision::new(rev.old_rev_as_ref(), None);
+        let rev_new = LanguageRevision::new(None, rev.new_rev_as_ref());
+
+        if old_commit.is_none() {
+            // Grab the HEAD source language and use it as our source
+            self.vcs.show(&source_path_vcs.to_string_lossy(), None, &source_path_out.to_string_lossy())?;
+        } else {
+            // Grab the old and new commits, query the changes, and use the output as our source
+            let old_path = rev_old.append_to_file_name(Path::new(temp_dir.path()).join(&source.file_name))?;
+            self.vcs.show(&source_path_vcs.to_string_lossy(), old_commit, &old_path.to_string_lossy())?;
+
+            let new_path = rev_new.append_to_file_name(Path::new(temp_dir.path()).join(&source.file_name))?;
+            self.vcs.show(&source_path_vcs.to_string_lossy(), new_commit, &new_path.to_string_lossy())?;
+
+            let query : query::CirupQuery;
+
+            query = query::query_change(&new_path.to_string_lossy(), &old_path.to_string_lossy());
+
+            query.run_interactive(Some(&source_path_out.to_string_lossy()));
+        }
+//
+
+        for (language, language_file) in &translations {
             println!("processing translation: {}", language);
 
             if language != &self.source_language {
                 let query_string = r"
                     SELECT
-                        A.key, A.val
-                    FROM A
-                    INNER JOIN B on (A.key = B.key) and (A.val = B.val)";
-                let query = query::CirupQuery::new(query_string, &source_language_path.to_string_lossy(), 
-                    Some(&path.to_string_lossy()));
+                        B.key, B.val
+                    FROM B
+                    INNER JOIN A on (A.key = B.key) AND (A.val <> B.val)";
 
-                if !query.run().is_empty() && !force {
-                    Err(format!(r"translation {} contains untranslated strings. 
-                    translate all strings or use use the force option.", language))?;
+                // let query_string = r"
+                //     SELECT
+                //         A.key, A.val
+                //     FROM A
+                //     INNER JOIN B on (A.key = B.key) and (A.val = B.val)";
+                let query = query::CirupQuery::new(query_string, &source_path_out.to_string_lossy(), 
+                    Some(&language_file.path.to_string_lossy()));
+                let file_path = rev.append_to_file_name(Path::new(temp_dir.path()).join(&language_file.file_name))?;
+                query.run_interactive(Some(&file_path.to_string_lossy()));
+                // if !query.run().is_empty() && !force {
+                //     Err(format!(r"translation {} contains untranslated strings. 
+                //     translate all strings or use use the force option.", language))?;
+                // }
+
+            // }
+
+                match self.languages.get(language) {
+                    Some(vcs_language_path) => {
+                        println!("merging {:?} into {:?}", language_file.path, vcs_language_path.path);
+                        let query = query::query_merge(&vcs_language_path.path.to_string_lossy(), &file_path.to_string_lossy());
+                        query.run_interactive(Some(&vcs_language_path.path.to_string_lossy()));
+                    },
+                    None => {
+                        println!("no source language for translation {}", language);
+                    },
                 }
-            }
-
-            match self.languages.get(language) {
-                Some(vcs_language_path) => {
-                    println!("merging {:?} into {:?}", path, vcs_language_path);
-                    let query = query::query_merge(&vcs_language_path.to_string_lossy(), &path.to_string_lossy());
-                    query.run_interactive(Some(&vcs_language_path.to_string_lossy()));
-                },
-                None => {
-                    println!("no source language for translation {}", language);
-                },
             }
         }
 
@@ -160,6 +370,17 @@ impl Sync {
 
         Ok(())
     }
+
+/*
+PULL
+-no old commit
+    diff source language with other languages
+-old commit
+    diff source language old and new (new strings)
+    diff that file with all the latest language files (missing translations)
+-with-changes
+    same as above, but show changed strings...
+*/
 
 /*
 If no old commit is specified:
@@ -173,74 +394,121 @@ If an old commit is specified:
     pub fn pull(
         &self, 
         old_commit: Option<&str>, 
-        new_commit: Option<&str>) 
+        new_commit: Option<&str>,
+        show_changes: bool) 
         -> Result<(), Box<Error>> {
-
-        let source_language_path = self.source_language_path();
-        let source_language_filename = source_language_path.file_name().unwrap();
         let temp_dir = tempdir()?;
-        let source_path = self.vcs_relative_path(source_language_filename);
-        let out_path = Path::new(&self.working_dir).join(source_language_filename);
+        let current_rev = sanitized(&self.vcs.current_revision()?).to_string();
+        let rev = LanguageRevision::new(old_commit, match new_commit {
+           Some(new_commit) => Some(new_commit),
+           None => Some(&current_rev)
+        });
+        let source = self.source_language().unwrap();
+        let source_path_vcs = self.vcs_relative_path(&source.file_name);
+        let source_path_out = rev.append_to_file_name(Path::new(&self.working_dir).join(&source.file_name))?;
+
+        let rev_old = LanguageRevision::new(rev.old_rev_as_ref(), None);
+        let rev_new = LanguageRevision::new(None, rev.new_rev_as_ref());
 
         if old_commit.is_none() {
             // Grab the HEAD source language and use it as our source
-            self.vcs.show(&source_path.to_string_lossy(), None, &out_path.to_string_lossy())?;
+            self.vcs.show(&source_path_vcs.to_string_lossy(), None, &source_path_out.to_string_lossy())?;
         } else {
             // Grab the old and new commits, query the changes, and use the output as our source
-            let old_filename = format!("{}.{}", 
-                old_commit.unwrap(), 
-                source_language_filename.to_string_lossy());
-            let new_filename = format!("{}.{}",
-                if new_commit.is_some() { new_commit.unwrap() } else { "HEAD"},
-                source_language_filename.to_string_lossy());
+            let old_path = rev_old.append_to_file_name(Path::new(temp_dir.path()).join(&source.file_name))?;
+            self.vcs.show(&source_path_vcs.to_string_lossy(), old_commit, &old_path.to_string_lossy())?;
 
-            let old_path = Path::new(temp_dir.path()).join(old_filename);
-            let new_path = Path::new(temp_dir.path()).join(new_filename);
+            let new_path = rev_new.append_to_file_name(Path::new(temp_dir.path()).join(&source.file_name))?;
+            self.vcs.show(&source_path_vcs.to_string_lossy(), new_commit, &new_path.to_string_lossy())?;
 
-            self.vcs.show(&source_path.to_string_lossy(), old_commit, &old_path.to_string_lossy())?;
-            self.vcs.show(&source_path.to_string_lossy(), new_commit, &new_path.to_string_lossy())?;
+            let query : query::CirupQuery;
 
-            let query = query::query_change(&new_path.to_string_lossy(), &old_path.to_string_lossy());
-            query.run_interactive(Some(&out_path.to_string_lossy()));
+            if show_changes {
+                query = query::query_change(&new_path.to_string_lossy(), &old_path.to_string_lossy());
+            } else {
+                query = query::query_diff(&new_path.to_string_lossy(), &old_path.to_string_lossy());
+            }
+            query.run_interactive(Some(&source_path_out.to_string_lossy()));
         }
 
-        for (language, path) in &self.languages {
+        for (language, language_file) in &self.languages {
             if language == &self.source_language {
                 continue
             }
 
-            let file_name = format!("{}.{}",
-                if new_commit.is_some() { new_commit.unwrap() } else { "HEAD"},
-                path.file_name().unwrap().to_string_lossy());
-            let file_path = Path::new(&temp_dir.path()).join(file_name);
+            let target_path_vcs = self.vcs_relative_path(&language_file.file_name);
+            let target_path_out = rev.append_to_file_name(Path::new(&self.working_dir).join(&language_file.file_name))?;
 
-            let target_language_filename = path.file_name().unwrap();
-            let target_path = self.vcs_relative_path(target_language_filename);
-            self.vcs.show(&target_path.to_string_lossy(), new_commit, &file_path.to_string_lossy())?;
-
-            let target_out_path = Path::new(&self.working_dir).join(target_language_filename);
+            let file_path = rev_new.append_to_file_name(Path::new(temp_dir.path()).join(&language_file.file_name))?;
+            self.vcs.show(&target_path_vcs.to_string_lossy(), new_commit, &file_path.to_string_lossy())?;
 
             let query : query::CirupQuery;
             
             if old_commit.is_none() {
-                query = query::query_diff(&out_path.to_string_lossy(), &file_path.to_string_lossy());
+                query = query::query_diff(&source_path_out.to_string_lossy(), &file_path.to_string_lossy());
             } else {
                 let query_string = r"
                     SELECT
-                        A.key,
-                        (CASE WHEN B.val IS NOT NULL
-                         THEN B.val
-                         ELSE A.val END)
+                        A.key, A.val
                     FROM A
                     LEFT OUTER JOIN B on A.key = B.key";
-                query = query::CirupQuery::new(query_string, &out_path.to_string_lossy(), Some(&file_path.to_string_lossy()));
+                query = query::CirupQuery::new(query_string, &source_path_out.to_string_lossy(), Some(&file_path.to_string_lossy()));
             }
             
-            query.run_interactive(Some(&target_out_path.to_string_lossy()));
+            query.run_interactive(Some(&target_path_out.to_string_lossy()));
 
-            info!("translation file generated: {:?}", target_out_path);
+            info!("translation file generated: {:?}", target_path_out);
         }
 
         Ok(())
     }
+}
+
+#[test]
+fn language_revision_to_string_test() {
+    let mut a = LanguageRevision { old_rev: Some("r123".to_string()), new_rev: Some("r456".to_string()) };
+    assert_eq!(a.to_string(), "r123-r456");
+    a = LanguageRevision { old_rev: Some("r123".to_string()), new_rev: None };
+    assert_eq!(a.to_string(), "r123");
+    a = LanguageRevision { old_rev: Some("r456".to_string()), new_rev: None };
+    assert_eq!(a.to_string(), "r456");
+    a = LanguageRevision { old_rev: None, new_rev: None };
+    assert_eq!(a.to_string(), "");
+}
+
+#[test]
+fn language_revision_from_string_test() {
+    let mut a = LanguageRevision::from_string("r123-r456");
+    assert_eq!(a.old_rev, Some("r123".to_string()));
+    assert_eq!(a.new_rev, Some("r456".to_string()));
+    a = LanguageRevision::from_string("r123");
+    assert_eq!(a.old_rev, None);
+    assert_eq!(a.new_rev, Some("r123".to_string()));
+    a = LanguageRevision::from_string("");
+    assert_eq!(a.old_rev, None);
+    assert_eq!(a.new_rev, None);
+    a = LanguageRevision::from_string("-");
+    assert_eq!(a.old_rev, None);
+    assert_eq!(a.new_rev, None);
+}
+
+#[test]
+fn language_revision_append_to_file_name_test() {
+    let mut p = PathBuf::from("/test/path/myfile.resx");
+    let rev = LanguageRevision { old_rev: Some("r123".to_string()), new_rev: Some("r456".to_string()) };
+    p = rev.append_to_file_name(p).unwrap();
+    assert_eq!(p, PathBuf::from("/test/path/myfile.~r123-r456~.resx"));
+}
+
+#[test]
+
+fn language_revision_extract_from_file_name_test() {
+    let (revision, path) = LanguageRevision::extract_from_file_name(PathBuf::from("/test/path/myfile.~r123-r456~.resx"));
+    assert_eq!(revision.old_rev, Some("r123".to_string()));
+    assert_eq!(revision.new_rev, Some("r456".to_string()));
+    assert_eq!(path, PathBuf::from("/test/path/myfile.resx"));
+    let (revision, path) = LanguageRevision::extract_from_file_name(PathBuf::from("/test/path/myfile.not.a.revision.resx"));
+    assert_eq!(revision.old_rev, None);
+    assert_eq!(revision.new_rev, None);
+    assert_eq!(path, PathBuf::from("/test/path/myfile.not.a.revision.resx"));
 }

--- a/cirup_core/src/sync.rs
+++ b/cirup_core/src/sync.rs
@@ -30,7 +30,7 @@ pub struct Sync {
 struct LanguageFile {
     path: PathBuf,
     file_name: String,
-    file_ext: String,
+    _file_ext: String,
     revision: RevisionRange,
 }
 
@@ -39,7 +39,7 @@ impl Default for LanguageFile {
         LanguageFile {
             path: PathBuf::default(),
             file_name: String::new(),
-            file_ext: String::new(),
+            _file_ext: String::new(),
             revision: RevisionRange::default(),
         }
     }
@@ -65,7 +65,7 @@ impl LanguageFile {
         Ok(LanguageFile {
             path: path_ref,
             file_name: file_name,
-            file_ext: file_ext,
+            _file_ext: file_ext,
             revision: language_revision
         })
     }

--- a/cirup_core/src/utils.rs
+++ b/cirup_core/src/utils.rs
@@ -1,0 +1,19 @@
+pub fn sanitized(component: &str) -> String {
+    let mut buf = String::with_capacity(component.len());
+    for (i, c) in component.chars().enumerate() {
+        let is_lower = 'a' <= c && c <= 'z';
+        let is_upper = 'A' <= c && c <= 'Z';
+        let is_letter = is_upper || is_lower;
+        let is_number = '0' <= c && c <= '9';
+        let is_space = c == ' ';
+        let is_hyphen = c == '-';
+        let is_underscore = c == '_';
+        let is_period = c == '.' && i != 0; // Disallow accidentally hidden folders
+        let is_valid = is_letter || is_number || is_space || is_hyphen || is_underscore ||
+                       is_period;
+        if is_valid {
+            buf.push(c);
+        }
+    }
+    buf
+}

--- a/cirup_core/src/utils.rs
+++ b/cirup_core/src/utils.rs
@@ -9,8 +9,8 @@ pub fn sanitized(component: &str) -> String {
         let is_hyphen = c == '-';
         let is_underscore = c == '_';
         let is_period = c == '.' && i != 0; // Disallow accidentally hidden folders
-        let is_valid = is_letter || is_number || is_space || is_hyphen || is_underscore ||
-                       is_period;
+        let is_valid =
+            is_letter || is_number || is_space || is_hyphen || is_underscore || is_period;
         if is_valid {
             buf.push(c);
         }

--- a/cirup_core/test/config.cirup
+++ b/cirup_core/test/config.cirup
@@ -5,8 +5,8 @@ remote_path = "git@bitbucket.org:devolutions/wayknow.git"
 
 [job]
 source_language = "en"
-source_match = "\\.json$"
-source_name_match = "(.+?)(\\.[^.]*$|$)"
+match_language_file = "\\.json$"
+match_language_name = "(.+?)(\\.[^.]*$|$)"
 source_dir = "resources/i18n"
 export_dir = "/tmp"
 import_dir = ""


### PR DESCRIPTION
- You can control the verbosity with `v` (e.g. `-vvv`)
- Better behaviour when the user is using an existing source control repo (we try to fetch the latest version, but error out if this would cause conflicts)
- Standardize the output of the `vcs-log` command:

`%commit% - %date% - %author% - %message%

Where `commit` is the short hash in git, and `date` is ISO formatted

- Add the ability to specify the target language(s)
- Pulling "updated" strings is now optional (with `--show-changes`). Mixed-language files are never created.
- The `force` option is no longer available when pushing; strings that have not been updated from the source language are simply not merged
- Filenames now contain the revision(s) that the operation was performed on. So for example, this command:

`cirup pull --old-commit r123 --new-commit r456`

Will produce translation files named like this:

`UIResources.fr.~123-456~.resx`

The file can be updated, then merged back with the corresponding `push`:

`cirup push --old-commit r123 --new-commit r456`

- Bug fixes, crashes and formatting!
