### PR TITLE
Stabilize cross-platform release workflow and deterministic RESX output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -78,31 +79,40 @@ jobs:
           cargo build --locked --release --package cirup_cli --bin cirup --target "${{ matrix.target }}"
 
       - name: Package artifact
-        shell: bash
+        shell: pwsh
         env:
           TARGET: ${{ matrix.target }}
           BIN_NAME: ${{ matrix.binary }}
           ARCHIVE_NAME: ${{ matrix.archive }}
         run: |
-          python - <<'PY'
-          import os
-          import pathlib
-          import zipfile
+          $target = $env:TARGET
+          $binName = $env:BIN_NAME
+          $archiveName = $env:ARCHIVE_NAME
 
-          target = os.environ['TARGET']
-          bin_name = os.environ['BIN_NAME']
-          archive_name = os.environ['ARCHIVE_NAME']
+          $binaryPath = [System.IO.Path]::Combine("target", $target, "release", $binName)
+          if (-not (Test-Path -Path $binaryPath)) {
+            throw "Binary not found: $binaryPath"
+          }
 
-          binary_path = pathlib.Path('target') / target / 'release' / bin_name
-          if not binary_path.exists():
-              raise SystemExit(f"Binary not found: {binary_path}")
+          if (Test-Path -Path $archiveName) {
+            Remove-Item -Path $archiveName -Force
+          }
 
-          archive_path = pathlib.Path(archive_name)
-          with zipfile.ZipFile(archive_path, 'w', compression=zipfile.ZIP_DEFLATED) as zipf:
-              zipf.write(binary_path, arcname=bin_name)
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $archive = [System.IO.Compression.ZipFile]::Open($archiveName, [System.IO.Compression.ZipArchiveMode]::Create)
+          try {
+            [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+              $archive,
+              $binaryPath,
+              $binName,
+              [System.IO.Compression.CompressionLevel]::Optimal
+            ) | Out-Null
+          }
+          finally {
+            $archive.Dispose()
+          }
 
-          print(f"Created {archive_path}")
-          PY
+          Write-Host "Created $archiveName"
 
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v4
@@ -115,6 +125,7 @@ jobs:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
             archive: cirup-windows-x64.zip
             binary: cirup.exe
 
+          # Upstream context: https://github.com/tursodatabase/turso/issues/4981
           - name: windows-arm64
             os: windows-latest
             target: aarch64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal --target "${{ matrix.target }}"
+          rustup default stable
 
       - name: Install Linux ARM64 linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -144,10 +142,11 @@ jobs:
           cat checksums.txt
 
       - name: Publish release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
-          files: |
-            dist/cirup-*.zip
-            dist/checksums.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release upload "${{ github.ref_name }}" dist/cirup-*.zip dist/checksums.txt --clobber
+          else
+            gh release create "${{ github.ref_name }}" dist/cirup-*.zip dist/checksums.txt --generate-notes
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             binary: cirup.exe
 
           - name: macos-x64
-            os: macos-13
+            os: macos-14
             target: x86_64-apple-darwin
             archive: cirup-macos-x64.zip
             binary: cirup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,17 +413,18 @@ dependencies = [
 
 [[package]]
 name = "cirup_cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cirup_core",
  "clap",
+ "embed-resource",
  "env_logger",
  "log",
 ]
 
 [[package]]
 name = "cirup_core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dot_json",
@@ -439,7 +440,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.4.10",
  "treexml",
  "turso",
  "uuid 0.6.5",
@@ -668,6 +669,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embed-resource"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
+dependencies = [
+ "cc",
+ "memchr",
+ "rustc_version",
+ "toml 0.9.12+spec-1.1.0",
+ "vswhom",
+ "winreg 0.55.0",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b917757416fe02ec0d303e669082fd04037d44c1a7cb170fc556a6f6889d3161"
 dependencies = [
  "winapi",
- "winreg",
+ "winreg 0.5.1",
 ]
 
 [[package]]
@@ -2429,6 +2444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2782,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,10 +2924,10 @@ dependencies = [
 [[package]]
 name = "treexml"
 version = "0.7.0"
-source = "git+https://github.com/awakecoding/treexml-rs.git?branch=indexmap#f668ac96d9971d19086f5736f3087502cdf3e195"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b58a77e81f51d427f9cc3a5966211e5be59e5f3c4bfc395babf536595a7609"
 dependencies = [
  "failure",
- "indexmap 1.7.0",
  "xml-rs",
 ]
 
@@ -3157,6 +3220,26 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -3604,12 +3687,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
 name = "winreg"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/cirup_cli/Cargo.toml
+++ b/cirup_cli/Cargo.toml
@@ -16,7 +16,12 @@ env_logger = "0.11"
 [build-dependencies]
 embed-resource = "3.0.6"
 
-[dependencies.cirup_core]
+[target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies.cirup_core]
+path = "../cirup_core"
+default-features = false
+features = ["rusqlite-c"]
+
+[target.'cfg(not(all(target_os = "windows", target_arch = "aarch64")))'.dependencies.cirup_core]
 path = "../cirup_core"
 
 [lints]

--- a/cirup_cli/Cargo.toml
+++ b/cirup_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirup_cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Marc-André Moreau <marcandre.moreau@gmail.com>"]
 edition = "2024"
 
@@ -12,6 +12,9 @@ path = "src/main.rs"
 clap = { version = "4.5", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
+
+[build-dependencies]
+embed-resource = "3.0.6"
 
 [dependencies.cirup_core]
 path = "../cirup_core"

--- a/cirup_cli/build.rs
+++ b/cirup_cli/build.rs
@@ -1,0 +1,98 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn normalize_windows_version(version: &str) -> (String, String) {
+    let semver_no_pre = version.split_once('-').map_or(version, |(core, _)| core);
+    let semver = semver_no_pre
+        .split_once('+')
+        .map_or(semver_no_pre, |(core, _)| core);
+
+    let mut parts = semver
+        .split('.')
+        .map(|part| part.parse::<u16>().unwrap_or(0))
+        .collect::<Vec<_>>();
+
+    while parts.len() < 4 {
+        parts.push(0);
+    }
+
+    parts.truncate(4);
+
+    let dots = parts
+        .iter()
+        .map(u16::to_string)
+        .collect::<Vec<_>>()
+        .join(".");
+    let commas = parts
+        .iter()
+        .map(u16::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+
+    (dots, commas)
+}
+
+fn generate_version_rc() -> String {
+    let package_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_owned());
+    let (version_dots, version_commas) = normalize_windows_version(package_version.as_str());
+
+    let company_name = "Devolutions Inc.";
+    let file_description = "cirup command-line tool";
+    let product_name = "cirup-rs";
+    let original_filename = "cirup.exe";
+    let legal_copyright = "Copyright 2019-2026 Devolutions Inc.";
+
+    format!(
+        r#"#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION {version_commas}
+PRODUCTVERSION {version_commas}
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+FILEFLAGS 0x0L
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_APP
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName", "{company_name}"
+            VALUE "FileDescription", "{file_description}"
+            VALUE "FileVersion", "{version_dots}"
+            VALUE "InternalName", "{original_filename}"
+            VALUE "LegalCopyright", "{legal_copyright}"
+            VALUE "OriginalFilename", "{original_filename}"
+            VALUE "ProductName", "{product_name}"
+            VALUE "ProductVersion", "{version_dots}"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+"#
+    )
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is not set"));
+    let version_rc_file = out_dir.join("version.rc");
+    let version_rc_data = generate_version_rc();
+
+    let mut file = File::create(&version_rc_file).expect("Failed to create version.rc file");
+    file.write_all(version_rc_data.as_bytes())
+        .expect("Failed to write version.rc file");
+
+    let _ = embed_resource::compile(&version_rc_file, embed_resource::NONE);
+}

--- a/cirup_core/Cargo.toml
+++ b/cirup_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cirup_core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Marc-André Moreau <marcandre.moreau@gmail.com>"]
 edition = "2024"
 
@@ -52,8 +52,7 @@ features = ["remote", "tls"]
 optional = true
 
 [dependencies.treexml]
-git = "https://github.com/awakecoding/treexml-rs.git"
-branch = "indexmap"
+version = "0.7"
 
 [lints]
 workspace = true

--- a/cirup_core/src/vcs.rs
+++ b/cirup_core/src/vcs.rs
@@ -233,7 +233,8 @@ struct Log {
 
 impl LogEntry {
     fn iso_formatted_date(&self) -> Result<String, Box<dyn Error>> {
-        let dt = Utc.datetime_from_str(self.date.trim_end_matches("Z"), "%Y-%m-%dT%H:%M:%S%.6f")?;
+        let dt = NaiveDateTime::parse_from_str(self.date.trim_end_matches("Z"), "%Y-%m-%dT%H:%M:%S%.6f")?
+            .and_utc();
         Ok(dt.to_rfc3339_opts(SecondsFormat::Secs, false))
     }
 }


### PR DESCRIPTION
## Summary
- switch 	reexml dependency to crates.io release and keep deterministic .resx output in core serializer
- embed Windows executable version metadata for cirup.exe
- make release workflow manually runnable without publishing releases
- replace Python artifact packaging with PowerShell implementation
- fix windows-arm64 workflow builds by using cirup_core with usqlite-c on that target
- run macos-x64 matrix leg on macos-14 while still targeting x86_64-apple-darwin

## Validation
- local checks and tests for updated code paths
- workflow run produced all 6 platform zip artifacts with publish job skipped
