### PR TITLE
Fix workflow policy compliance and static MSVC runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add rustfmt clippy --toolchain stable
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.8.2
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -51,10 +53,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.8.2
+
+      - name: Configure static MSVC runtime
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          "RUSTFLAGS=-C target-feature=+crt-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Run tests
         run: cargo test --workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Configure static MSVC runtime
+        if: contains(matrix.target, 'windows-msvc')
+        shell: pwsh
+        run: |
+          "RUSTFLAGS=-C target-feature=+crt-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Build binary
         shell: bash
         env:

--- a/cirup_cli/build.rs
+++ b/cirup_cli/build.rs
@@ -5,9 +5,7 @@ use std::path::PathBuf;
 
 fn normalize_windows_version(version: &str) -> (String, String) {
     let semver_no_pre = version.split_once('-').map_or(version, |(core, _)| core);
-    let semver = semver_no_pre
-        .split_once('+')
-        .map_or(semver_no_pre, |(core, _)| core);
+    let semver = semver_no_pre.split_once('+').map_or(semver_no_pre, |(core, _)| core);
 
     let mut parts = semver
         .split('.')
@@ -20,16 +18,8 @@ fn normalize_windows_version(version: &str) -> (String, String) {
 
     parts.truncate(4);
 
-    let dots = parts
-        .iter()
-        .map(u16::to_string)
-        .collect::<Vec<_>>()
-        .join(".");
-    let commas = parts
-        .iter()
-        .map(u16::to_string)
-        .collect::<Vec<_>>()
-        .join(",");
+    let dots = parts.iter().map(u16::to_string).collect::<Vec<_>>().join(".");
+    let commas = parts.iter().map(u16::to_string).collect::<Vec<_>>().join(",");
 
     (dots, commas)
 }

--- a/cirup_core/src/query.rs
+++ b/cirup_core/src/query.rs
@@ -42,8 +42,10 @@ fn default_query_backend() -> QueryBackendKind {
 }
 
 fn default_query_config() -> QueryConfig {
-    let mut query_config = QueryConfig::default();
-    query_config.backend = default_query_backend();
+    let mut query_config = QueryConfig {
+        backend: default_query_backend(),
+        ..QueryConfig::default()
+    };
 
     query_config.turso.url = std::env::var("CIRUP_TURSO_URL")
         .ok()
@@ -372,8 +374,10 @@ fn test_query_turso_remote_env_gated() {
         .or_else(|| std::env::var("TURSO_AUTH_TOKEN").ok())
         .unwrap_or_default();
 
-    let mut query_config = QueryConfig::default();
-    query_config.backend = QueryBackendKind::TursoRemote;
+    let mut query_config = QueryConfig {
+        backend: QueryBackendKind::TursoRemote,
+        ..QueryConfig::default()
+    };
     query_config.turso.url = Some(remote_url);
     if !remote_auth_token.is_empty() {
         query_config.turso.auth_token = Some(remote_auth_token);

--- a/cirup_core/src/query_backend.rs
+++ b/cirup_core/src/query_backend.rs
@@ -64,8 +64,7 @@ const QUERY_SORT_A: &str = "select * from a order by a.key";
 #[cfg(feature = "turso-rust")]
 const QUERY_DIFF: &str = "select a.key, a.val, b.val from a left outer join b on a.key = b.key where (b.val is null)";
 #[cfg(feature = "turso-rust")]
-const QUERY_DIFF_WITH_BASE: &str =
-    "select b.key, b.val, c.val from b left outer join a on b.key = a.key inner join c on b.key = c.key where (a.val is null)";
+const QUERY_DIFF_WITH_BASE: &str = "select b.key, b.val, c.val from b left outer join a on b.key = a.key inner join c on b.key = c.key where (a.val is null)";
 #[cfg(feature = "turso-rust")]
 const QUERY_CHANGE: &str =
     "select a.key, a.val, b.val from a left outer join b on a.key = b.key where (b.val is null) or (a.val <> b.val)";
@@ -505,9 +504,7 @@ impl TursoLocalBackend {
 
             for resource in a {
                 let pair = (resource.name.as_str(), resource.value.as_str());
-                if b_pairs.contains(&pair)
-                    && dedupe.insert((resource.name.clone(), resource.value.clone()))
-                {
+                if b_pairs.contains(&pair) && dedupe.insert((resource.name.clone(), resource.value.clone())) {
                     resources.push(resource.clone());
                 }
             }
@@ -540,10 +537,7 @@ impl TursoLocalBackend {
 
             let mut resources = Vec::new();
             for resource in a {
-                let repeat = b_match_count
-                    .get(resource.name.as_str())
-                    .copied()
-                    .unwrap_or(1);
+                let repeat = b_match_count.get(resource.name.as_str()).copied().unwrap_or(1);
                 for _ in 0..repeat {
                     resources.push(resource.clone());
                 }
@@ -856,7 +850,9 @@ pub(crate) fn build_backend(query_config: &QueryConfig) -> Box<dyn QueryBackend>
 
             #[cfg(not(feature = "rusqlite-c"))]
             {
-                warn!("rusqlite backend requested but 'rusqlite-c' feature is disabled, falling back to available backend");
+                warn!(
+                    "rusqlite backend requested but 'rusqlite-c' feature is disabled, falling back to available backend"
+                );
                 return fallback_backend();
             }
         }
@@ -874,7 +870,9 @@ pub(crate) fn build_backend(query_config: &QueryConfig) -> Box<dyn QueryBackend>
 
             #[cfg(not(feature = "turso-rust"))]
             {
-                warn!("turso-remote backend requested but 'turso-rust' feature is disabled, falling back to available backend");
+                warn!(
+                    "turso-remote backend requested but 'turso-rust' feature is disabled, falling back to available backend"
+                );
             }
 
             fallback_backend()
@@ -887,7 +885,9 @@ pub(crate) fn build_backend(query_config: &QueryConfig) -> Box<dyn QueryBackend>
 
             #[cfg(not(feature = "turso-rust"))]
             {
-                warn!("turso-local backend requested but 'turso-rust' feature is disabled, falling back to available backend");
+                warn!(
+                    "turso-local backend requested but 'turso-rust' feature is disabled, falling back to available backend"
+                );
                 fallback_backend()
             }
         }

--- a/cirup_core/src/resx.rs
+++ b/cirup_core/src/resx.rs
@@ -17,16 +17,11 @@ fn without_bom(text: &str) -> &[u8] {
 }
 
 fn escape_xml_text(value: &str) -> String {
-    value
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
+    value.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
 
 fn escape_xml_attr(value: &str) -> String {
-    escape_xml_text(value)
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
+    escape_xml_text(value).replace('"', "&quot;").replace('\'', "&apos;")
 }
 
 impl FileFormat for ResxFileFormat {

--- a/cirup_core/src/vcs.rs
+++ b/cirup_core/src/vcs.rs
@@ -233,8 +233,7 @@ struct Log {
 
 impl LogEntry {
     fn iso_formatted_date(&self) -> Result<String, Box<dyn Error>> {
-        let dt = NaiveDateTime::parse_from_str(self.date.trim_end_matches("Z"), "%Y-%m-%dT%H:%M:%S%.6f")?
-            .and_utc();
+        let dt = NaiveDateTime::parse_from_str(self.date.trim_end_matches("Z"), "%Y-%m-%dT%H:%M:%S%.6f")?.and_utc();
         Ok(dt.to_rfc3339_opts(SecondsFormat::Secs, false))
     }
 }

--- a/cirup_core/tests/benchmark_rdm_resx.rs
+++ b/cirup_core/tests/benchmark_rdm_resx.rs
@@ -78,22 +78,12 @@ fn normalize_triples(triples: &mut [Triple]) {
 fn triples_to_tuples(triples: &[Triple]) -> Vec<(String, String, String)> {
     triples
         .iter()
-        .map(|triple| {
-            (
-                triple.name.clone(),
-                triple.value.clone(),
-                triple.base.clone(),
-            )
-        })
+        .map(|triple| (triple.name.clone(), triple.value.clone(), triple.base.clone()))
         .collect()
 }
 
 #[cfg(all(feature = "turso-rust", feature = "rusqlite-c"))]
-fn benchmark_resource_operation<F>(
-    label: &str,
-    ordered: bool,
-    mut operation: F,
-) -> (Duration, Duration, usize)
+fn benchmark_resource_operation<F>(label: &str, ordered: bool, mut operation: F) -> (Duration, Duration, usize)
 where
     F: FnMut(QueryBackendKind) -> Vec<Resource>,
 {
@@ -108,17 +98,11 @@ where
     let rows = rusqlite_result.len();
 
     if ordered {
-        assert_eq!(
-            rusqlite_result, turso_result,
-            "ordered result mismatch for {label}"
-        );
+        assert_eq!(rusqlite_result, turso_result, "ordered result mismatch for {label}");
     } else {
         normalize(&mut rusqlite_result);
         normalize(&mut turso_result);
-        assert_eq!(
-            rusqlite_result, turso_result,
-            "result mismatch for {label}"
-        );
+        assert_eq!(rusqlite_result, turso_result, "result mismatch for {label}");
     }
 
     (rusqlite_elapsed, turso_elapsed, rows)
@@ -145,10 +129,7 @@ where
     let rusqlite_tuples = triples_to_tuples(&rusqlite_result);
     let turso_tuples = triples_to_tuples(&turso_result);
 
-    assert_eq!(
-        rusqlite_tuples, turso_tuples,
-        "triple result mismatch for {label}"
-    );
+    assert_eq!(rusqlite_tuples, turso_tuples, "triple result mismatch for {label}");
 
     (rusqlite_elapsed, turso_elapsed, rows)
 }
@@ -250,8 +231,7 @@ fn benchmark_correctness_rusqlite_vs_turso_local() {
         macro_rules! bench_resource_op {
             ($key:expr, $label:expr, $ordered:expr, $run:expr) => {{
                 covered_operations.insert($key);
-                let (rusqlite_elapsed, turso_elapsed, rows) =
-                    benchmark_resource_operation($label, $ordered, $run);
+                let (rusqlite_elapsed, turso_elapsed, rows) = benchmark_resource_operation($label, $ordered, $run);
                 total_rusqlite += rusqlite_elapsed;
                 total_turso += turso_elapsed;
                 println!(
@@ -348,14 +328,7 @@ fn benchmark_correctness_rusqlite_vs_turso_local() {
             &format!("{} / pull-query-left-join(en,fr)", triplet.name),
             false,
             |backend| {
-                query::CirupQuery::new_with_backend(
-                    pull_left_join_query,
-                    &en,
-                    Some(&fr),
-                    None,
-                    backend,
-                )
-                .run()
+                query::CirupQuery::new_with_backend(pull_left_join_query, &en, Some(&fr), None, backend).run()
             }
         );
 
@@ -364,14 +337,7 @@ fn benchmark_correctness_rusqlite_vs_turso_local() {
             &format!("{} / push-query-changed-values(en,fr)", triplet.name),
             false,
             |backend| {
-                query::CirupQuery::new_with_backend(
-                    push_changed_values_query,
-                    &en,
-                    Some(&fr),
-                    None,
-                    backend,
-                )
-                .run()
+                query::CirupQuery::new_with_backend(push_changed_values_query, &en, Some(&fr), None, backend).run()
             }
         );
     }
@@ -388,7 +354,5 @@ fn benchmark_correctness_rusqlite_vs_turso_local() {
         total_rusqlite, total_turso, ratio
     );
 
-    println!(
-        "analyzed non-query CLI operations (not query-backend comparable): vcs-log, vcs-diff"
-    );
+    println!("analyzed non-query CLI operations (not query-backend comparable): vcs-log, vcs-diff");
 }


### PR DESCRIPTION
## Summary
- replace disallowed workflow action usage with rustup-based setup in CI
- pin rust cache action to allowlisted version (Swatinem/rust-cache@v2.8.2)
- enforce static MSVC runtime for Windows CI/tests and release builds (RUSTFLAGS=-C target-feature=+crt-static)
- update release matrix to run macOS x64 target on macOS 14
- keep windows-arm64 release build path working via target-specific cirup_core feature selection
- resolve lint/clippy issues so CI passes on the branch

## Validation
- CI run passed on ix-stuff: https://github.com/Devolutions/cirup-rs/actions/runs/22416343066
