### PR TITLE
Allow manual release publishing and use pwsh in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build/publish (for example v0.1.0)
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -57,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         shell: pwsh
@@ -77,7 +84,7 @@ jobs:
           "RUSTFLAGS=-C target-feature=+crt-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build binary
-        shell: bash
+        shell: pwsh
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: |
@@ -130,7 +137,9 @@ jobs:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
 
     steps:
       - name: Download artifacts
@@ -139,21 +148,42 @@ jobs:
           path: dist
 
       - name: Flatten artifact directories
+        shell: pwsh
         run: |
-          find dist -type f -name '*.zip' -exec mv {} dist/ \;
+          Get-ChildItem -Path dist -Recurse -File -Filter '*.zip' |
+            ForEach-Object {
+              Move-Item -Path $_.FullName -Destination (Join-Path -Path (Get-Location) -ChildPath 'dist') -Force
+            }
 
       - name: Generate checksums
+        shell: pwsh
         working-directory: dist
         run: |
-          sha256sum cirup-*.zip > checksums.txt
-          cat checksums.txt
+          $lines = Get-ChildItem -File -Filter 'cirup-*.zip' |
+            Sort-Object Name |
+            ForEach-Object {
+              $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+              "$hash  $($_.Name)"
+            }
+
+          $lines | Set-Content -Path checksums.txt -Encoding utf8
+          Get-Content -Path checksums.txt
 
       - name: Publish release assets
+        shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
         run: |
-          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
-            gh release upload "${{ github.ref_name }}" dist/cirup-*.zip dist/checksums.txt --clobber
-          else
-            gh release create "${{ github.ref_name }}" dist/cirup-*.zip dist/checksums.txt --generate-notes
-          fi
+          $zipFiles = Get-ChildItem -Path dist -File -Filter 'cirup-*.zip' |
+            Sort-Object Name |
+            ForEach-Object { $_.FullName }
+
+          gh release view "$env:RELEASE_TAG" *> $null
+
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload "$env:RELEASE_TAG" @zipFiles "dist/checksums.txt" --clobber
+          }
+          else {
+            gh release create "$env:RELEASE_TAG" @zipFiles "dist/checksums.txt" --generate-notes
+          }


### PR DESCRIPTION
## Summary
- allow manual release publishing via workflow_dispatch with required tag input
- check out the selected tag during manual runs so artifacts are built from the release ref
- allow publish job for both tag pushes and manual dispatch with v* tag input
- convert release workflow script steps to pwsh (including build and publish path)

## Validation
- workflow diagnostics in editor reported no YAML/expression errors
- branch pushed successfully: fix-release