### PR TITLE
Fix release workflow dispatch checkout and tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Install Rust toolchain
         shell: pwsh
@@ -174,6 +174,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+          RELEASE_TARGET: ${{ github.sha }}
         run: |
           $zipFiles = Get-ChildItem -Path dist -File -Filter 'cirup-*.zip' |
             Sort-Object Name |
@@ -185,5 +186,18 @@ jobs:
             gh release upload "$env:RELEASE_TAG" @zipFiles "dist/checksums.txt" --clobber
           }
           else {
-            gh release create "$env:RELEASE_TAG" @zipFiles "dist/checksums.txt" --generate-notes
+            $createArgs = @(
+              "$env:RELEASE_TAG"
+            )
+
+            $createArgs += $zipFiles
+            $createArgs += "dist/checksums.txt"
+            $createArgs += "--generate-notes"
+
+            if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+              $createArgs += "--target"
+              $createArgs += "$env:RELEASE_TARGET"
+            }
+
+            gh release create @createArgs
           }


### PR DESCRIPTION
## Summary
- fix workflow_dispatch checkout to use the workflow run ref instead of the input tag
- ensure manual release creation can create a missing tag at the current run commit
- keep push-tag behavior unchanged

## Why
Manual release runs should build from the selected branch/commit and create the tag when creating the GitHub release, instead of requiring a pre-existing tag for checkout.