### PR TITLE
Fix release artifact merge in publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,38 +147,18 @@ jobs:
         with:
           path: dist
 
-      - name: Flatten artifact directories
-        shell: pwsh
-        run: |
-          $artifactDirs = Get-ChildItem -Path dist -Directory
-
-          $zipFiles = $artifactDirs |
-            ForEach-Object {
-              Get-ChildItem -Path $_.FullName -File -Filter 'cirup-*.zip'
-            }
-
-          $duplicateNames = $zipFiles |
-            Group-Object -Property Name |
-            Where-Object { $_.Count -gt 1 }
-
-          if ($duplicateNames) {
-            $names = $duplicateNames |
-              ForEach-Object { $_.Name } |
-              Sort-Object
-
-            throw "Duplicate archive names across artifacts: $($names -join ', ')"
-          }
-
-          $zipFiles |
-            ForEach-Object {
-              Move-Item -Path $_.FullName -Destination (Join-Path -Path 'dist' -ChildPath $_.Name) -Force
-            }
-
       - name: Generate checksums
         shell: pwsh
         working-directory: dist
         run: |
-          $lines = Get-ChildItem -File -Filter 'cirup-*.zip' |
+          $zipFiles = Get-ChildItem -Recurse -File -Filter 'cirup-*.zip' |
+            Sort-Object Name
+
+          if (-not $zipFiles) {
+            throw 'No release archives found under dist'
+          }
+
+          $lines = $zipFiles |
             Sort-Object Name |
             ForEach-Object {
               $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -195,9 +175,13 @@ jobs:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
           RELEASE_TARGET: ${{ github.sha }}
         run: |
-          $zipFiles = Get-ChildItem -Path dist -File -Filter 'cirup-*.zip' |
+          $zipFiles = Get-ChildItem -Path dist -Recurse -File -Filter 'cirup-*.zip' |
             Sort-Object Name |
             ForEach-Object { $_.FullName }
+
+          if (-not $zipFiles) {
+            throw 'No release archives found under dist'
+          }
 
           gh release view "$env:RELEASE_TAG" *> $null
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,14 +146,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
-
-      - name: Flatten artifact directories
-        shell: pwsh
-        run: |
-          Get-ChildItem -Path dist -Recurse -File -Filter '*.zip' |
-            ForEach-Object {
-              Move-Item -Path $_.FullName -Destination (Join-Path -Path (Get-Location) -ChildPath 'dist') -Force
-            }
+          merge-multiple: true
 
       - name: Generate checksums
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,33 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
-          merge-multiple: true
+
+      - name: Flatten artifact directories
+        shell: pwsh
+        run: |
+          $artifactDirs = Get-ChildItem -Path dist -Directory
+
+          $zipFiles = $artifactDirs |
+            ForEach-Object {
+              Get-ChildItem -Path $_.FullName -File -Filter 'cirup-*.zip'
+            }
+
+          $duplicateNames = $zipFiles |
+            Group-Object -Property Name |
+            Where-Object { $_.Count -gt 1 }
+
+          if ($duplicateNames) {
+            $names = $duplicateNames |
+              ForEach-Object { $_.Name } |
+              Sort-Object
+
+            throw "Duplicate archive names across artifacts: $($names -join ', ')"
+          }
+
+          $zipFiles |
+            ForEach-Object {
+              Move-Item -Path $_.FullName -Destination (Join-Path -Path 'dist' -ChildPath $_.Name) -Force
+            }
 
       - name: Generate checksums
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
           RELEASE_TARGET: ${{ github.sha }}
         run: |


### PR DESCRIPTION
## Summary
- use merge-multiple: true in artifact download for the publish job
- remove manual flatten step that moved zip files into dist

## Why
The manual flatten step reprocessed files already in dist, causing same-path collisions (ile already exists) and failing the release workflow.