### PR TITLE
Add RID-specific dotnet tool packaging for cirup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,43 @@ jobs:
           name: devolutions-cirup-build-nupkg-dry-run
           path: dist/nuget/Devolutions.Cirup.Build.*.nupkg
           if-no-files-found: error
+
+  pack_dotnet_tool_dry_run:
+    name: Dry-run dotnet tool pack
+    runs-on: ubuntu-latest
+    needs: build_release_artifacts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Import binaries and pack dotnet tool (dry-run)
+        shell: pwsh
+        env:
+          CI_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          $version = "0.0.0-ci.$env:CI_RUN_NUMBER"
+          $stagingRoot = Join-Path $PWD "nuget/staging"
+
+          ./nuget/pack-cirup-dotnet-tool.ps1 `
+            -Version $version `
+            -ArtifactsRoot "dist" `
+            -StagingRoot $stagingRoot `
+            -OutputDir "dist/nuget"
+
+      - name: Upload dry-run dotnet tool artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devolutions-cirup-tool-nupkg-dry-run
+          path: dist/nuget/Devolutions.Cirup.Tool*.nupkg
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ on:
         description: Release tag to build/publish (for example v0.1.0)
         required: true
         type: string
+      publish_nuget:
+        description: Publish packages to NuGet.org
+        required: false
+        default: false
+        type: boolean
+      dry_run_nuget:
+        description: Dry-run NuGet publish (simulate push commands)
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -139,6 +149,7 @@ jobs:
     needs:
       - build
       - pack_nuget
+      - pack_dotnet_tool
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
@@ -156,7 +167,8 @@ jobs:
           $releaseAssets = Get-ChildItem -Recurse -File |
             Where-Object {
               $_.Name -like 'cirup-*.zip' -or
-              $_.Name -like 'Devolutions.Cirup.Build.*.nupkg'
+              $_.Name -like 'Devolutions.Cirup.Build.*.nupkg' -or
+              $_.Name -like 'Devolutions.Cirup.Tool*.nupkg'
             } |
             Sort-Object Name
 
@@ -185,7 +197,8 @@ jobs:
           $assets = Get-ChildItem -Path dist -Recurse -File |
             Where-Object {
               $_.Name -like 'cirup-*.zip' -or
-              $_.Name -like 'Devolutions.Cirup.Build.*.nupkg'
+              $_.Name -like 'Devolutions.Cirup.Build.*.nupkg' -or
+              $_.Name -like 'Devolutions.Cirup.Tool*.nupkg'
             } |
             Sort-Object Name |
             ForEach-Object { $_.FullName }
@@ -263,3 +276,192 @@ jobs:
           name: devolutions-cirup-build-nupkg
           path: dist/nuget/Devolutions.Cirup.Build.*.nupkg
           if-no-files-found: error
+
+  pack_dotnet_tool:
+    name: Pack dotnet tool from prebuilt binaries
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Import binaries and pack dotnet tool
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+        run: |
+          $tag = $env:RELEASE_TAG
+          if (-not $tag.StartsWith('v')) {
+            throw "Release tag must start with 'v'. Actual: $tag"
+          }
+
+          $version = $tag.Substring(1)
+          $stagingRoot = Join-Path $PWD "nuget/staging"
+
+          ./nuget/pack-cirup-dotnet-tool.ps1 `
+            -Version $version `
+            -ArtifactsRoot "dist" `
+            -StagingRoot $stagingRoot `
+            -OutputDir "dist/nuget"
+
+      - name: Upload dotnet tool artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devolutions-cirup-tool-nupkg
+          path: dist/nuget/Devolutions.Cirup.Tool*.nupkg
+          if-no-files-found: error
+
+  publish_nuget:
+    name: Publish NuGet packages
+    runs-on: ubuntu-latest
+    needs:
+      - pack_nuget
+      - pack_dotnet_tool
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v') && github.event.inputs.publish_nuget == 'true')
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Resolve publish mode
+        id: publish_mode
+        shell: pwsh
+        env:
+          NUGET_BOT_USERNAME: ${{ secrets.NUGET_BOT_USERNAME }}
+        run: |
+          $dryRun = $false
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            try {
+              $dryRun = [System.Boolean]::Parse('${{ github.event.inputs.dry_run_nuget }}')
+            }
+            catch {
+              $dryRun = $true
+            }
+          }
+
+          $hasLoginUser = -not [string]::IsNullOrWhiteSpace($env:NUGET_BOT_USERNAME)
+
+          "dry_run=$($dryRun.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "has_login_user=$($hasLoginUser.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          if (-not $dryRun -and -not $hasLoginUser) {
+            Write-Host "NuGet publish skipped because NUGET_BOT_USERNAME is not configured."
+          }
+
+          Write-Host "NuGet dry-run mode: $dryRun"
+
+      - name: Download package artifacts
+        if: steps.publish_mode.outputs.dry_run == 'true' || steps.publish_mode.outputs.has_login_user == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Setup .NET SDK
+        if: steps.publish_mode.outputs.dry_run == 'true' || steps.publish_mode.outputs.has_login_user == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: NuGet login (OIDC)
+        if: steps.publish_mode.outputs.dry_run != 'true' && steps.publish_mode.outputs.has_login_user == 'true'
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_BOT_USERNAME }}
+
+      - name: Publish to NuGet.org (RID first, pointer last)
+        if: steps.publish_mode.outputs.dry_run == 'true' || steps.publish_mode.outputs.has_login_user == 'true'
+        shell: pwsh
+        env:
+          NUGET_SOURCE: https://api.nuget.org/v3/index.json
+        run: |
+          $dryRun = [System.Boolean]::Parse('${{ steps.publish_mode.outputs.dry_run }}')
+          $apiKey = '${{ steps.nuget-login.outputs.NUGET_API_KEY }}'
+
+          if ($dryRun) {
+            $apiKey = 'dry-run-key'
+            Write-Host 'Dry Run: NuGet push commands will be printed but not executed.'
+          }
+          elseif ([string]::IsNullOrWhiteSpace($apiKey)) {
+            throw 'NuGet login did not return an API key.'
+          }
+
+          $buildPackages = Get-ChildItem -Path dist -Recurse -File -Filter 'Devolutions.Cirup.Build.*.nupkg' | Sort-Object Name
+          if (-not $buildPackages) {
+            throw 'Missing Devolutions.Cirup.Build package artifact.'
+          }
+
+          foreach ($package in $buildPackages) {
+            $pushArgs = @(
+              'nuget', 'push', "$($package.FullName)",
+              '--api-key', "$apiKey",
+              '--source', "$env:NUGET_SOURCE",
+              '--skip-duplicate', '--no-symbols'
+            )
+
+            Write-Host "dotnet $($pushArgs -join ' ')"
+            if (-not $dryRun) {
+              & dotnet @pushArgs
+            }
+          }
+
+          $toolPackages = Get-ChildItem -Path dist -Recurse -File -Filter 'Devolutions.Cirup.Tool*.nupkg' | Sort-Object Name
+          if (-not $toolPackages) {
+            throw 'Missing Devolutions.Cirup.Tool package artifacts.'
+          }
+
+          $toolRidPattern = 'Devolutions\.Cirup\.Tool\.(win-x64|win-arm64|linux-x64|linux-arm64|osx-x64|osx-arm64|any)\.'
+          $toolRidPackages = $toolPackages | Where-Object { $_.Name -match $toolRidPattern }
+          $toolPointerPackages = $toolPackages | Where-Object { $_.Name -notmatch $toolRidPattern }
+
+          if (-not $toolRidPackages) {
+            throw 'Missing Devolutions.Cirup.Tool RID package artifacts.'
+          }
+
+          if (-not $toolPointerPackages) {
+            throw 'Missing Devolutions.Cirup.Tool pointer package artifact.'
+          }
+
+          foreach ($package in $toolRidPackages) {
+            $pushArgs = @(
+              'nuget', 'push', "$($package.FullName)",
+              '--api-key', "$apiKey",
+              '--source', "$env:NUGET_SOURCE",
+              '--skip-duplicate', '--no-symbols'
+            )
+
+            Write-Host "dotnet $($pushArgs -join ' ')"
+            if (-not $dryRun) {
+              & dotnet @pushArgs
+            }
+          }
+
+          foreach ($package in $toolPointerPackages) {
+            $pushArgs = @(
+              'nuget', 'push', "$($package.FullName)",
+              '--api-key', "$apiKey",
+              '--source', "$env:NUGET_SOURCE",
+              '--skip-duplicate', '--no-symbols'
+            )
+
+            Write-Host "dotnet $($pushArgs -join ' ')"
+            if (-not $dryRun) {
+              & dotnet @pushArgs
+            }
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/
 .idea/
 target/
+nuget/tool/bin/
+nuget/tool/obj/

--- a/README.md
+++ b/README.md
@@ -150,6 +150,30 @@ Run local end-to-end validation:
 pwsh ./nuget/test-e2e.ps1
 ```
 
+## Dotnet tool usage (.NET 10+)
+
+`cirup` is also available as a RID-specific dotnet tool package: `Devolutions.Cirup.Tool`.
+
+Install globally:
+
+```bash
+dotnet tool install -g Devolutions.Cirup.Tool
+cirup --help
+```
+
+Run one-shot without permanent install:
+
+```bash
+dotnet tool exec Devolutions.Cirup.Tool -- --help
+dnx Devolutions.Cirup.Tool --help
+```
+
+Create local dotnet tool packages from prebuilt release artifacts:
+
+```bash
+pwsh ./nuget/pack-cirup-dotnet-tool.ps1 -Version 1.2.3 -ArtifactsRoot ./dist -OutputDir ./dist/nuget
+```
+
 ## Quality checks
 
 ```bash

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -105,3 +105,32 @@ Run the full local validation flow from the repository root:
 ```powershell
 ./nuget/test-e2e.ps1
 ```
+
+## RID-specific dotnet tool package
+
+The repository also ships a separate RID-specific dotnet tool package: `Devolutions.Cirup.Tool`.
+
+- Package type: dotnet tool (command name `cirup`)
+- SDK requirement: .NET 10 SDK or newer
+- Supported RIDs: `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`
+- Includes an `any` fallback package that prints a guidance message on unsupported runtimes
+
+Install and run:
+
+```powershell
+dotnet tool install -g Devolutions.Cirup.Tool
+cirup --help
+```
+
+One-shot usage:
+
+```powershell
+dotnet tool exec Devolutions.Cirup.Tool -- --help
+dnx Devolutions.Cirup.Tool --help
+```
+
+Pack from prebuilt native artifacts (same artifact input as `Devolutions.Cirup.Build`):
+
+```powershell
+./nuget/pack-cirup-dotnet-tool.ps1 -Version 1.2.3 -ArtifactsRoot ./dist -OutputDir ./dist/nuget
+```

--- a/nuget/pack-cirup-dotnet-tool.ps1
+++ b/nuget/pack-cirup-dotnet-tool.ps1
@@ -11,16 +11,17 @@ $ErrorActionPreference = "Stop"
 
 . (Join-Path $PSScriptRoot "scripts/Import-CirupArtifacts.ps1")
 
-$packageProject = Join-Path $PSScriptRoot "Devolutions.Cirup.Build.Package.csproj"
+$packageProject = Join-Path $PSScriptRoot "tool/Devolutions.Cirup.Tool.csproj"
+
 New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
 
 Import-CirupArtifacts -ArtifactsRoot $ArtifactsRoot -StagingRoot $StagingRoot
 
-Write-Host "Packing Devolutions.Cirup.Build $Version"
+Write-Host "Packing Devolutions.Cirup.Tool $Version"
 dotnet pack $packageProject `
     -c Release `
     -p:Version=$Version `
-    -p:CirupNugetStagingDir=$stagingRoot `
+    -p:CirupNugetStagingDir=$StagingRoot `
     -o $OutputDir
 
 if ($LASTEXITCODE -ne 0) {

--- a/nuget/scripts/Import-CirupArtifacts.ps1
+++ b/nuget/scripts/Import-CirupArtifacts.ps1
@@ -1,0 +1,72 @@
+Set-StrictMode -Version Latest
+
+function Get-CirupArchivePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Root,
+        [Parameter(Mandatory = $true)]
+        [string]$ArchiveName
+    )
+
+    $match = Get-ChildItem -Path $Root -Recurse -File -Filter $ArchiveName | Select-Object -First 1
+    if (-not $match) {
+        throw "Archive not found under '$Root': $ArchiveName"
+    }
+
+    return $match.FullName
+}
+
+function Import-CirupArtifacts {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ArtifactsRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StagingRoot,
+
+        [string]$ToolsRelativePath = "tools/cirup"
+    )
+
+    $extractRoot = Join-Path $StagingRoot "extract"
+    $toolsRoot = Join-Path $StagingRoot $ToolsRelativePath
+
+    if (Test-Path -Path $StagingRoot) {
+        Remove-Item -Path $StagingRoot -Recurse -Force
+    }
+
+    New-Item -Path $extractRoot -ItemType Directory -Force | Out-Null
+    New-Item -Path $toolsRoot -ItemType Directory -Force | Out-Null
+
+    $archives = @(
+        @{ Archive = "cirup-windows-x64.zip"; Rid = "win-x64"; Binary = "cirup.exe" },
+        @{ Archive = "cirup-windows-arm64.zip"; Rid = "win-arm64"; Binary = "cirup.exe" },
+        @{ Archive = "cirup-linux-x64.zip"; Rid = "linux-x64"; Binary = "cirup" },
+        @{ Archive = "cirup-linux-arm64.zip"; Rid = "linux-arm64"; Binary = "cirup" },
+        @{ Archive = "cirup-macos-x64.zip"; Rid = "osx-x64"; Binary = "cirup" },
+        @{ Archive = "cirup-macos-arm64.zip"; Rid = "osx-arm64"; Binary = "cirup" }
+    )
+
+    foreach ($entry in $archives) {
+        $archivePath = Get-CirupArchivePath -Root $ArtifactsRoot -ArchiveName $entry.Archive
+        $extractDir = Join-Path $extractRoot $entry.Rid
+        $destDir = Join-Path $toolsRoot $entry.Rid
+        $destPath = Join-Path $destDir $entry.Binary
+
+        New-Item -Path $extractDir -ItemType Directory -Force | Out-Null
+        New-Item -Path $destDir -ItemType Directory -Force | Out-Null
+
+        Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+        $sourcePath = Join-Path $extractDir $entry.Binary
+        if (-not (Test-Path -Path $sourcePath)) {
+            $nested = Get-ChildItem -Path $extractDir -Recurse -File -Filter $entry.Binary | Select-Object -First 1
+            if (-not $nested) {
+                throw "Unable to find '$($entry.Binary)' in archive '$archivePath'."
+            }
+
+            $sourcePath = $nested.FullName
+        }
+
+        Copy-Item -Path $sourcePath -Destination $destPath -Force
+    }
+}

--- a/nuget/tool/Devolutions.Cirup.Tool.csproj
+++ b/nuget/tool/Devolutions.Cirup.Tool.csproj
@@ -1,0 +1,76 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>cirup</ToolCommandName>
+    <PackageId>Devolutions.Cirup.Tool</PackageId>
+
+    <Version Condition="'$(Version)' == ''">0.0.0-local</Version>
+    <Authors>Devolutions</Authors>
+    <Description>RID-specific dotnet tool wrapper around prebuilt cirup native executables.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Devolutions/cirup-rs</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64;any</RuntimeIdentifiers>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CirupNugetStagingDir Condition="'$(CirupNugetStagingDir)' == ''">$(MSBuildProjectDirectory)\..\staging</CirupNugetStagingDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
+
+    <None Include="$(CirupNugetStagingDir)\tools\cirup\win-x64\cirup.exe"
+          Pack="true"
+          PackagePath="tools\net10.0\any\cirup.exe"
+          Visible="false"
+          Condition="'$(RuntimeIdentifier)' == 'win-x64' and Exists('$(CirupNugetStagingDir)\tools\cirup\win-x64\cirup.exe')" />
+    <None Include="$(CirupNugetStagingDir)\tools\cirup\win-arm64\cirup.exe"
+          Pack="true"
+          PackagePath="tools\net10.0\any\cirup.exe"
+          Visible="false"
+          Condition="'$(RuntimeIdentifier)' == 'win-arm64' and Exists('$(CirupNugetStagingDir)\tools\cirup\win-arm64\cirup.exe')" />
+
+    <None Include="$(CirupNugetStagingDir)\tools\cirup\linux-x64\cirup"
+          Pack="true"
+          PackagePath="tools\net10.0\any\cirup"
+          Visible="false"
+          Condition="'$(RuntimeIdentifier)' == 'linux-x64' and Exists('$(CirupNugetStagingDir)\tools\cirup\linux-x64\cirup')" />
+    <None Include="$(CirupNugetStagingDir)\tools\cirup\linux-arm64\cirup"
+          Pack="true"
+          PackagePath="tools\net10.0\any\cirup"
+          Visible="false"
+          Condition="'$(RuntimeIdentifier)' == 'linux-arm64' and Exists('$(CirupNugetStagingDir)\tools\cirup\linux-arm64\cirup')" />
+
+    <None Include="$(CirupNugetStagingDir)\tools\cirup\osx-x64\cirup"
+          Pack="true"
+          PackagePath="tools\net10.0\any\cirup"
+          Visible="false"
+          Condition="'$(RuntimeIdentifier)' == 'osx-x64' and Exists('$(CirupNugetStagingDir)\tools\cirup\osx-x64\cirup')" />
+    <None Include="$(CirupNugetStagingDir)\tools\cirup\osx-arm64\cirup"
+          Pack="true"
+          PackagePath="tools\net10.0\any\cirup"
+          Visible="false"
+          Condition="'$(RuntimeIdentifier)' == 'osx-arm64' and Exists('$(CirupNugetStagingDir)\tools\cirup\osx-arm64\cirup')" />
+  </ItemGroup>
+
+  <Target Name="ValidateCirupToolStaging"
+          BeforeTargets="GenerateNuspec"
+          Condition="'$(RuntimeIdentifier)' != '' and '$(RuntimeIdentifier)' != 'any'">
+    <PropertyGroup>
+      <_CirupToolBinaryPath>$(CirupNugetStagingDir)\tools\cirup\$(RuntimeIdentifier)\cirup</_CirupToolBinaryPath>
+      <_CirupToolBinaryPath Condition="'$(RuntimeIdentifier)' == 'win-x64' or '$(RuntimeIdentifier)' == 'win-arm64'">$(CirupNugetStagingDir)\tools\cirup\$(RuntimeIdentifier)\cirup.exe</_CirupToolBinaryPath>
+    </PropertyGroup>
+
+    <Error Condition="!Exists('$(_CirupToolBinaryPath)')"
+           Text="Missing staged binary for RuntimeIdentifier '$(RuntimeIdentifier)': $(_CirupToolBinaryPath)" />
+  </Target>
+</Project>

--- a/nuget/tool/Devolutions.Cirup.Tool.csproj
+++ b/nuget/tool/Devolutions.Cirup.Tool.csproj
@@ -30,34 +30,34 @@
 
     <None Include="$(CirupNugetStagingDir)\tools\cirup\win-x64\cirup.exe"
           Pack="true"
-          PackagePath="tools\net10.0\any\cirup.exe"
+          PackagePath="tools\net10.0\win-x64\cirup.exe"
           Visible="false"
           Condition="'$(RuntimeIdentifier)' == 'win-x64' and Exists('$(CirupNugetStagingDir)\tools\cirup\win-x64\cirup.exe')" />
     <None Include="$(CirupNugetStagingDir)\tools\cirup\win-arm64\cirup.exe"
           Pack="true"
-          PackagePath="tools\net10.0\any\cirup.exe"
+          PackagePath="tools\net10.0\win-arm64\cirup.exe"
           Visible="false"
           Condition="'$(RuntimeIdentifier)' == 'win-arm64' and Exists('$(CirupNugetStagingDir)\tools\cirup\win-arm64\cirup.exe')" />
 
     <None Include="$(CirupNugetStagingDir)\tools\cirup\linux-x64\cirup"
           Pack="true"
-          PackagePath="tools\net10.0\any\cirup"
+          PackagePath="tools\net10.0\linux-x64\cirup"
           Visible="false"
           Condition="'$(RuntimeIdentifier)' == 'linux-x64' and Exists('$(CirupNugetStagingDir)\tools\cirup\linux-x64\cirup')" />
     <None Include="$(CirupNugetStagingDir)\tools\cirup\linux-arm64\cirup"
           Pack="true"
-          PackagePath="tools\net10.0\any\cirup"
+          PackagePath="tools\net10.0\linux-arm64\cirup"
           Visible="false"
           Condition="'$(RuntimeIdentifier)' == 'linux-arm64' and Exists('$(CirupNugetStagingDir)\tools\cirup\linux-arm64\cirup')" />
 
     <None Include="$(CirupNugetStagingDir)\tools\cirup\osx-x64\cirup"
           Pack="true"
-          PackagePath="tools\net10.0\any\cirup"
+          PackagePath="tools\net10.0\osx-x64\cirup"
           Visible="false"
           Condition="'$(RuntimeIdentifier)' == 'osx-x64' and Exists('$(CirupNugetStagingDir)\tools\cirup\osx-x64\cirup')" />
     <None Include="$(CirupNugetStagingDir)\tools\cirup\osx-arm64\cirup"
           Pack="true"
-          PackagePath="tools\net10.0\any\cirup"
+          PackagePath="tools\net10.0\osx-arm64\cirup"
           Visible="false"
           Condition="'$(RuntimeIdentifier)' == 'osx-arm64' and Exists('$(CirupNugetStagingDir)\tools\cirup\osx-arm64\cirup')" />
   </ItemGroup>

--- a/nuget/tool/Program.cs
+++ b/nuget/tool/Program.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+return Run(args);
+
+static int Run(string[] args)
+{
+    string executableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cirup.exe" : "cirup";
+    string nativeExecutablePath = Path.Combine(AppContext.BaseDirectory, executableName);
+
+    if (!File.Exists(nativeExecutablePath))
+    {
+        PrintUnsupportedRidMessage();
+        return 1;
+    }
+
+    EnsureExecutableBit(nativeExecutablePath);
+
+    var processStartInfo = new ProcessStartInfo(nativeExecutablePath)
+    {
+        UseShellExecute = false,
+    };
+
+    foreach (string argument in args)
+    {
+        processStartInfo.ArgumentList.Add(argument);
+    }
+
+    using Process process = Process.Start(processStartInfo);
+    if (process is null)
+    {
+        Console.Error.WriteLine("Unable to start native cirup executable.");
+        return 1;
+    }
+
+    process.WaitForExit();
+    return process.ExitCode;
+}
+
+static void PrintUnsupportedRidMessage()
+{
+    Console.Error.WriteLine("No native cirup executable is available for this runtime identifier in this package.");
+    Console.Error.WriteLine($"Detected runtime identifier: {RuntimeInformation.RuntimeIdentifier}");
+    Console.Error.WriteLine("Supported runtime identifiers: win-x64, win-arm64, linux-x64, linux-arm64, osx-x64, osx-arm64.");
+    Console.Error.WriteLine("Install the tool on a supported platform, or download platform-specific binaries from cirup release assets.");
+}
+
+static void EnsureExecutableBit(string nativeExecutablePath)
+{
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+        return;
+    }
+
+    const string chmodPath = "/bin/chmod";
+    if (!File.Exists(chmodPath))
+    {
+        return;
+    }
+
+    try
+    {
+        var chmodStartInfo = new ProcessStartInfo(chmodPath)
+        {
+            UseShellExecute = false,
+        };
+        chmodStartInfo.ArgumentList.Add("+x");
+        chmodStartInfo.ArgumentList.Add(nativeExecutablePath);
+
+        using Process chmodProcess = Process.Start(chmodStartInfo);
+        chmodProcess?.WaitForExit();
+    }
+    catch
+    {
+    }
+}

--- a/nuget/tool/README.md
+++ b/nuget/tool/README.md
@@ -1,0 +1,42 @@
+# Devolutions.Cirup.Tool
+
+`Devolutions.Cirup.Tool` is a RID-specific .NET tool package for `cirup`.
+
+## Install
+
+```powershell
+dotnet tool install -g Devolutions.Cirup.Tool
+```
+
+## Run
+
+```powershell
+cirup --help
+```
+
+## One-shot run
+
+```powershell
+dotnet tool exec Devolutions.Cirup.Tool -- --help
+```
+
+or with the .NET 10 shortcut:
+
+```powershell
+dnx Devolutions.Cirup.Tool --help
+```
+
+## Runtime selection
+
+The package uses RID-specific tool packaging. The .NET CLI automatically selects the best package for the current platform.
+
+Supported RIDs:
+
+- `win-x64`
+- `win-arm64`
+- `linux-x64`
+- `linux-arm64`
+- `osx-x64`
+- `osx-arm64`
+
+An `any` fallback package is also produced. It provides a managed fallback message on unsupported runtimes.


### PR DESCRIPTION
## Summary
- add a new RID-specific dotnet tool package: Devolutions.Cirup.Tool
- reuse the same prebuilt Rust cirup artifacts used by existing NuGet packaging
- add a dedicated pack script for the tool package and shared artifact-import script
- extend CI and release workflows to produce/upload tool nupkgs with release assets
- add optional NuGet publish workflow path aligned with OIDC login pattern
- update README and nuget docs for tool install/exec/dnx usage

## Notes
- keeps existing Devolutions.Cirup.Build package behavior intact
- publishes RID packages before tool pointer package when NuGet publishing is enabled