### PR TITLE
Harden release flow: branch env switch + sign-once artifact reuse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,7 +405,8 @@ jobs:
     needs:
       - preflight
       - sign_windows
-      - sign_nupkg
+      - pack_nuget
+      - pack_dotnet_tool
 
     steps:
       - name: Download platform zip artifacts
@@ -548,7 +549,7 @@ jobs:
       - name: Upload NuGet artifact
         uses: actions/upload-artifact@v4
         with:
-          name: devolutions-cirup-build-nupkg-unsigned
+          name: devolutions-cirup-build-nupkg
           path: dist/nuget/Devolutions.Cirup.Build.*.nupkg
           if-no-files-found: error
 
@@ -598,167 +599,8 @@ jobs:
       - name: Upload dotnet tool artifact
         uses: actions/upload-artifact@v4
         with:
-          name: devolutions-cirup-tool-nupkg-unsigned
-          path: dist/nuget/Devolutions.Cirup.Tool*.nupkg
-          if-no-files-found: error
-
-  sign_nupkg:
-    name: Sign NuGet package binaries
-    runs-on: windows-latest
-    needs:
-      - preflight
-      - pack_nuget
-      - pack_dotnet_tool
-    environment: ${{ needs.preflight.outputs.publish_env }}
-
-    steps:
-      - name: Download unsigned build NuGet artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: devolutions-cirup-build-nupkg-unsigned
-          path: dist/unsigned/build
-
-      - name: Download unsigned dotnet tool NuGet artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: devolutions-cirup-tool-nupkg-unsigned
-          path: dist/unsigned/tool
-
-      - name: Resolve signing mode
-        id: signing_mode
-        shell: pwsh
-        env:
-          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
-          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
-          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
-          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
-        run: |
-          $dryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry_run }}')
-          $publishEnv = '${{ needs.preflight.outputs.publish_env }}'
-          $isTestSigning = $publishEnv -eq 'publish-test'
-
-          $requiredValues = @(
-            $env:CODE_SIGNING_KEYVAULT_URL,
-            $env:AZURE_TENANT_ID,
-            $env:CODE_SIGNING_CLIENT_ID,
-            $env:CODE_SIGNING_CLIENT_SECRET,
-            $env:CODE_SIGNING_CERTIFICATE_NAME,
-            $env:CODE_SIGNING_TIMESTAMP_SERVER
-          )
-
-          $hasSigningSecrets = $true
-          foreach ($value in $requiredValues) {
-            if ([string]::IsNullOrWhiteSpace($value)) {
-              $hasSigningSecrets = $false
-              break
-            }
-          }
-
-          if ($isTestSigning) {
-            $shouldSign = $hasSigningSecrets
-          }
-          else {
-            $shouldSign = -not $dryRun -and $hasSigningSecrets
-          }
-
-          "dry_run=$($dryRun.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "should_sign=$($shouldSign.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-          if ($isTestSigning -and -not $hasSigningSecrets) {
-            throw 'Code signing secrets are required for test code signing in publish-test.'
-          }
-
-          if (-not $dryRun -and -not $hasSigningSecrets) {
-            throw 'Code signing secrets are required for non-dry-run release jobs.'
-          }
-
-          Write-Host "NuGet package signing dry-run mode: $dryRun"
-          Write-Host "NuGet package binaries will be signed: $shouldSign"
-
-      - name: Install AzureSignTool
-        if: steps.signing_mode.outputs.should_sign == 'true'
-        shell: pwsh
-        run: |
-          $toolPath = Join-Path $env:USERPROFILE '.dotnet\tools\AzureSignTool.exe'
-          if (Test-Path -Path $toolPath) {
-            dotnet tool update --global AzureSignTool
-          }
-          else {
-            dotnet tool install --global AzureSignTool
-          }
-
-      - name: Sign package binaries and prepare signed nupkgs
-        shell: pwsh
-        env:
-          SHOULD_SIGN: ${{ steps.signing_mode.outputs.should_sign }}
-          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
-          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
-          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
-          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
-        run: |
-          $shouldSign = [System.Boolean]::Parse($env:SHOULD_SIGN)
-          $unsignedPackages = Get-ChildItem -Path 'dist/unsigned' -Recurse -File -Filter '*.nupkg' | Sort-Object Name
-          if (-not $unsignedPackages) {
-            throw 'No unsigned NuGet packages found under dist/unsigned.'
-          }
-
-          $signedOutputRoot = Join-Path $PWD 'dist/signed'
-          if (Test-Path -Path $signedOutputRoot) {
-            Remove-Item -Path $signedOutputRoot -Recurse -Force
-          }
-
-          New-Item -Path $signedOutputRoot -ItemType Directory -Force | Out-Null
-          $toolPath = Join-Path $env:USERPROFILE '.dotnet\tools\AzureSignTool.exe'
-
-          foreach ($package in $unsignedPackages) {
-            $extractDir = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString('N'))
-            New-Item -Path $extractDir -ItemType Directory -Force | Out-Null
-
-            Expand-Archive -Path $package.FullName -DestinationPath $extractDir -Force
-
-            if ($shouldSign) {
-              $windowsBinaries = Get-ChildItem -Path $extractDir -Recurse -File | Where-Object {
-                ($_.Extension -in '.exe', '.dll') -and ($_.FullName -match '(\\|/)win-(x64|arm64)(\\|/)')
-              }
-
-              foreach ($binary in $windowsBinaries) {
-                & $toolPath sign `
-                  -kvt "$env:AZURE_TENANT_ID" `
-                  -kvu "$env:CODE_SIGNING_KEYVAULT_URL" `
-                  -kvi "$env:CODE_SIGNING_CLIENT_ID" `
-                  -kvs "$env:CODE_SIGNING_CLIENT_SECRET" `
-                  -kvc "$env:CODE_SIGNING_CERTIFICATE_NAME" `
-                  -tr "$env:CODE_SIGNING_TIMESTAMP_SERVER" `
-                  -v `
-                  "$($binary.FullName)"
-              }
-            }
-
-            $signedPackagePath = Join-Path $signedOutputRoot $package.Name
-            if (Test-Path -Path $signedPackagePath) {
-              Remove-Item -Path $signedPackagePath -Force
-            }
-
-            Compress-Archive -Path (Join-Path $extractDir '*') -DestinationPath $signedPackagePath -CompressionLevel Optimal
-            Remove-Item -Path $extractDir -Recurse -Force
-          }
-
-      - name: Upload signed build NuGet artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: devolutions-cirup-build-nupkg
-          path: dist/signed/Devolutions.Cirup.Build.*.nupkg
-          if-no-files-found: error
-
-      - name: Upload signed dotnet tool NuGet artifact
-        uses: actions/upload-artifact@v4
-        with:
           name: devolutions-cirup-tool-nupkg
-          path: dist/signed/Devolutions.Cirup.Tool*.nupkg
+          path: dist/nuget/Devolutions.Cirup.Tool*.nupkg
           if-no-files-found: error
 
   publish_nuget:
@@ -766,7 +608,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - preflight
-      - sign_nupkg
+      - pack_nuget
+      - pack_dotnet_tool
     if: needs.preflight.outputs.publish_nuget == 'true'
     environment: ${{ needs.preflight.outputs.publish_env }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,87 @@ permissions:
   contents: write
 
 jobs:
+  preflight:
+    name: Resolve release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.info.outputs.release_tag }}
+      publish_env: ${{ steps.info.outputs.publish_env }}
+      publish_nuget: ${{ steps.info.outputs.publish_nuget }}
+      dry_run: ${{ steps.info.outputs.dry_run }}
+    steps:
+      - name: Resolve release info
+        id: info
+        shell: pwsh
+        run: |
+          function Parse-BoolOrDefault {
+            param(
+              [string]$Value,
+              [bool]$Default
+            )
+
+            if ([string]::IsNullOrWhiteSpace($Value)) {
+              return $Default
+            }
+
+            try {
+              return [System.Boolean]::Parse($Value)
+            }
+            catch {
+              return $Default
+            }
+          }
+
+          $eventName = '${{ github.event_name }}'
+          $githubRef = '${{ github.ref }}'
+
+          if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
+            $releaseTag = '${{ github.ref_name }}'
+          }
+          else {
+            $releaseTag = '${{ github.event.inputs.tag }}'
+          }
+
+          if (-not $releaseTag.StartsWith('v')) {
+            throw "Release tag must start with 'v'. Actual: $releaseTag"
+          }
+
+          if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
+            $publishEnv = 'publish-prod'
+            $publishNuget = $true
+          }
+          else {
+            $publishEnv = 'publish-test'
+            $publishNuget = Parse-BoolOrDefault '${{ github.event.inputs.publish_nuget }}' $false
+          }
+
+          $dryRun = $false
+          if ($eventName -eq 'workflow_dispatch') {
+            $dryRun = Parse-BoolOrDefault '${{ github.event.inputs.dry_run_nuget }}' $true
+          }
+
+          if ($publishEnv -ne 'publish-prod') {
+            $dryRun = $true
+          }
+
+          if (-not $publishNuget) {
+            $dryRun = $true
+          }
+
+          "release_tag=$releaseTag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "publish_env=$publishEnv" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "publish_nuget=$($publishNuget.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "dry_run=$($dryRun.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          Write-Host "::notice::Release tag: $releaseTag"
+          Write-Host "::notice::Publish environment: $publishEnv"
+          Write-Host "::notice::Publish NuGet: $($publishNuget.ToString().ToLowerInvariant())"
+          Write-Host "::notice::NuGet dry-run: $($dryRun.ToString().ToLowerInvariant())"
+
   build:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +151,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ needs.preflight.outputs.release_tag }}
 
       - name: Install Rust toolchain
         shell: pwsh
@@ -101,6 +179,7 @@ jobs:
           cargo build --locked --release --package cirup_cli --bin cirup --target "${{ matrix.target }}"
 
       - name: Package artifact
+        if: ${{ !contains(matrix.target, 'windows-msvc') }}
         shell: pwsh
         env:
           TARGET: ${{ matrix.target }}
@@ -137,22 +216,165 @@ jobs:
           Write-Host "Created $archiveName"
 
       - name: Upload packaged artifact
+        if: ${{ !contains(matrix.target, 'windows-msvc') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.archive }}
           path: ${{ matrix.archive }}
           if-no-files-found: error
 
+      - name: Upload unsigned Windows binary
+        if: ${{ contains(matrix.target, 'windows-msvc') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.archive }}-unsigned-bin
+          path: target/${{ matrix.target }}/release/${{ matrix.binary }}
+          if-no-files-found: error
+
+  sign_windows:
+    name: Sign and package Windows artifacts
+    runs-on: windows-latest
+    needs:
+      - preflight
+      - build
+    environment: ${{ needs.preflight.outputs.publish_env }}
+
+    steps:
+      - name: Download unsigned Windows x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: cirup-windows-x64.zip-unsigned-bin
+          path: work/win-x64
+
+      - name: Download unsigned Windows arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: cirup-windows-arm64.zip-unsigned-bin
+          path: work/win-arm64
+
+      - name: Resolve signing mode
+        id: signing_mode
+        shell: pwsh
+        env:
+          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
+          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
+          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
+          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
+        run: |
+          $dryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry_run }}')
+
+          $requiredValues = @(
+            $env:CODE_SIGNING_KEYVAULT_URL,
+            $env:AZURE_TENANT_ID,
+            $env:CODE_SIGNING_CLIENT_ID,
+            $env:CODE_SIGNING_CLIENT_SECRET,
+            $env:CODE_SIGNING_CERTIFICATE_NAME,
+            $env:CODE_SIGNING_TIMESTAMP_SERVER
+          )
+
+          $hasSigningSecrets = $true
+          foreach ($value in $requiredValues) {
+            if ([string]::IsNullOrWhiteSpace($value)) {
+              $hasSigningSecrets = $false
+              break
+            }
+          }
+
+          $shouldSign = -not $dryRun -and $hasSigningSecrets
+
+          "dry_run=$($dryRun.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "should_sign=$($shouldSign.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          if (-not $dryRun -and -not $hasSigningSecrets) {
+            throw 'Code signing secrets are required for non-dry-run release jobs.'
+          }
+
+          Write-Host "Windows signing dry-run mode: $dryRun"
+          Write-Host "Windows binaries will be signed: $shouldSign"
+
+      - name: Install AzureSignTool
+        if: steps.signing_mode.outputs.should_sign == 'true'
+        shell: pwsh
+        run: |
+          $toolPath = Join-Path $env:USERPROFILE '.dotnet\tools\AzureSignTool.exe'
+          if (Test-Path -Path $toolPath) {
+            dotnet tool update --global AzureSignTool
+          }
+          else {
+            dotnet tool install --global AzureSignTool
+          }
+
+      - name: Code sign Windows executables
+        if: steps.signing_mode.outputs.should_sign == 'true'
+        shell: pwsh
+        env:
+          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
+          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
+          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
+          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
+        run: |
+          $toolPath = Join-Path $env:USERPROFILE '.dotnet\tools\AzureSignTool.exe'
+
+          & $toolPath sign `
+            -kvt "$env:AZURE_TENANT_ID" `
+            -kvu "$env:CODE_SIGNING_KEYVAULT_URL" `
+            -kvi "$env:CODE_SIGNING_CLIENT_ID" `
+            -kvs "$env:CODE_SIGNING_CLIENT_SECRET" `
+            -kvc "$env:CODE_SIGNING_CERTIFICATE_NAME" `
+            -tr "$env:CODE_SIGNING_TIMESTAMP_SERVER" `
+            -v `
+            "work/win-x64/cirup.exe"
+
+          & $toolPath sign `
+            -kvt "$env:AZURE_TENANT_ID" `
+            -kvu "$env:CODE_SIGNING_KEYVAULT_URL" `
+            -kvi "$env:CODE_SIGNING_CLIENT_ID" `
+            -kvs "$env:CODE_SIGNING_CLIENT_SECRET" `
+            -kvc "$env:CODE_SIGNING_CERTIFICATE_NAME" `
+            -tr "$env:CODE_SIGNING_TIMESTAMP_SERVER" `
+            -v `
+            "work/win-arm64/cirup.exe"
+
+      - name: Package Windows artifacts
+        shell: pwsh
+        run: |
+          if (Test-Path -Path 'cirup-windows-x64.zip') {
+            Remove-Item -Path 'cirup-windows-x64.zip' -Force
+          }
+
+          if (Test-Path -Path 'cirup-windows-arm64.zip') {
+            Remove-Item -Path 'cirup-windows-arm64.zip' -Force
+          }
+
+          Compress-Archive -Path 'work/win-x64/cirup.exe' -DestinationPath 'cirup-windows-x64.zip' -Force
+          Compress-Archive -Path 'work/win-arm64/cirup.exe' -DestinationPath 'cirup-windows-arm64.zip' -Force
+
+      - name: Upload artifact cirup-windows-x64.zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: cirup-windows-x64.zip
+          path: cirup-windows-x64.zip
+          if-no-files-found: error
+
+      - name: Upload artifact cirup-windows-arm64.zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: cirup-windows-arm64.zip
+          path: cirup-windows-arm64.zip
+          if-no-files-found: error
+
   publish:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs:
-      - build
+      - preflight
+      - sign_windows
       - pack_nuget
       - pack_dotnet_tool
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
 
     steps:
       - name: Download artifacts
@@ -191,7 +413,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
           RELEASE_TARGET: ${{ github.sha }}
         run: |
           $assets = Get-ChildItem -Path dist -Recurse -File |
@@ -232,7 +454,9 @@ jobs:
   pack_nuget:
     name: Pack NuGet from prebuilt binaries
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - preflight
+      - sign_windows
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
@@ -254,7 +478,7 @@ jobs:
       - name: Import binaries and pack NuGet
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
         run: |
           $tag = $env:RELEASE_TAG
           if (-not $tag.StartsWith('v')) {
@@ -280,7 +504,9 @@ jobs:
   pack_dotnet_tool:
     name: Pack dotnet tool from prebuilt binaries
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - preflight
+      - sign_windows
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
@@ -302,7 +528,7 @@ jobs:
       - name: Import binaries and pack dotnet tool
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
         run: |
           $tag = $env:RELEASE_TAG
           if (-not $tag.StartsWith('v')) {
@@ -329,11 +555,11 @@ jobs:
     name: Publish NuGet packages
     runs-on: ubuntu-latest
     needs:
+      - preflight
       - pack_nuget
       - pack_dotnet_tool
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v') && github.event.inputs.publish_nuget == 'true')
+    if: needs.preflight.outputs.publish_nuget == 'true'
+    environment: ${{ needs.preflight.outputs.publish_env }}
     permissions:
       id-token: write
       contents: read
@@ -345,15 +571,7 @@ jobs:
         env:
           NUGET_BOT_USERNAME: ${{ secrets.NUGET_BOT_USERNAME }}
         run: |
-          $dryRun = $false
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            try {
-              $dryRun = [System.Boolean]::Parse('${{ github.event.inputs.dry_run_nuget }}')
-            }
-            catch {
-              $dryRun = $true
-            }
-          }
+          $dryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry_run }}')
 
           $hasLoginUser = -not [string]::IsNullOrWhiteSpace($env:NUGET_BOT_USERNAME)
 
@@ -361,7 +579,7 @@ jobs:
           "has_login_user=$($hasLoginUser.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
           if (-not $dryRun -and -not $hasLoginUser) {
-            Write-Host "NuGet publish skipped because NUGET_BOT_USERNAME is not configured."
+            throw 'NUGET_BOT_USERNAME is required when dry_run is false.'
           }
 
           Write-Host "NuGet dry-run mode: $dryRun"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
       publish_nuget: ${{ steps.info.outputs.publish_nuget }}
       dry_run: ${{ steps.info.outputs.dry_run }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Resolve release info
         id: info
         shell: pwsh
@@ -58,9 +63,19 @@ jobs:
 
           $eventName = '${{ github.event_name }}'
           $githubRef = '${{ github.ref }}'
+          $sourceBranch = '${{ github.ref_name }}'
 
           if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
             $releaseTag = '${{ github.ref_name }}'
+
+            git fetch --prune --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
+            $containsMaster = @(git branch -r --contains '${{ github.sha }}' | ForEach-Object { $_.Trim() }) -contains 'origin/master'
+            if ($containsMaster) {
+              $sourceBranch = 'master'
+            }
+            else {
+              $sourceBranch = 'non-master'
+            }
           }
           else {
             $releaseTag = '${{ github.event.inputs.tag }}'
@@ -70,12 +85,17 @@ jobs:
             throw "Release tag must start with 'v'. Actual: $releaseTag"
           }
 
-          if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
+          if ($sourceBranch -eq 'master') {
             $publishEnv = 'publish-prod'
-            $publishNuget = $true
           }
           else {
             $publishEnv = 'publish-test'
+          }
+
+          if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
+            $publishNuget = $true
+          }
+          else {
             $publishNuget = Parse-BoolOrDefault '${{ github.event.inputs.publish_nuget }}' $false
           }
 
@@ -98,6 +118,7 @@ jobs:
           "dry_run=$($dryRun.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
           Write-Host "::notice::Release tag: $releaseTag"
+          Write-Host "::notice::Source branch: $sourceBranch"
           Write-Host "::notice::Publish environment: $publishEnv"
           Write-Host "::notice::Publish NuGet: $($publishNuget.ToString().ToLowerInvariant())"
           Write-Host "::notice::NuGet dry-run: $($dryRun.ToString().ToLowerInvariant())"
@@ -264,6 +285,8 @@ jobs:
           CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
         run: |
           $dryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry_run }}')
+          $publishEnv = '${{ needs.preflight.outputs.publish_env }}'
+          $isTestSigning = $publishEnv -eq 'publish-test'
 
           $requiredValues = @(
             $env:CODE_SIGNING_KEYVAULT_URL,
@@ -282,10 +305,19 @@ jobs:
             }
           }
 
-          $shouldSign = -not $dryRun -and $hasSigningSecrets
+          if ($isTestSigning) {
+            $shouldSign = $hasSigningSecrets
+          }
+          else {
+            $shouldSign = -not $dryRun -and $hasSigningSecrets
+          }
 
           "dry_run=$($dryRun.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "should_sign=$($shouldSign.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          if ($isTestSigning -and -not $hasSigningSecrets) {
+            throw 'Code signing secrets are required for test code signing in publish-test.'
+          }
 
           if (-not $dryRun -and -not $hasSigningSecrets) {
             throw 'Code signing secrets are required for non-dry-run release jobs.'
@@ -409,6 +441,7 @@ jobs:
           Get-Content -Path checksums.txt
 
       - name: Publish release assets
+        if: needs.preflight.outputs.dry_run != 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
@@ -450,6 +483,12 @@ jobs:
 
             gh release create @createArgs
           }
+
+      - name: "Dry Run: skip GitHub release publish"
+        if: needs.preflight.outputs.dry_run == 'true'
+        shell: pwsh
+        run: |
+          Write-Host 'Dry Run: skipping GitHub release create/upload.'
 
   pack_nuget:
     name: Pack NuGet from prebuilt binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,13 +405,25 @@ jobs:
     needs:
       - preflight
       - sign_windows
-      - pack_nuget
-      - pack_dotnet_tool
+      - sign_nupkg
 
     steps:
-      - name: Download artifacts
+      - name: Download platform zip artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: cirup-*.zip
+          path: dist
+
+      - name: Download signed build NuGet artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: devolutions-cirup-build-nupkg
+          path: dist
+
+      - name: Download signed dotnet tool NuGet artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: devolutions-cirup-tool-nupkg
           path: dist
 
       - name: Generate checksums
@@ -536,7 +548,7 @@ jobs:
       - name: Upload NuGet artifact
         uses: actions/upload-artifact@v4
         with:
-          name: devolutions-cirup-build-nupkg
+          name: devolutions-cirup-build-nupkg-unsigned
           path: dist/nuget/Devolutions.Cirup.Build.*.nupkg
           if-no-files-found: error
 
@@ -586,8 +598,167 @@ jobs:
       - name: Upload dotnet tool artifact
         uses: actions/upload-artifact@v4
         with:
-          name: devolutions-cirup-tool-nupkg
+          name: devolutions-cirup-tool-nupkg-unsigned
           path: dist/nuget/Devolutions.Cirup.Tool*.nupkg
+          if-no-files-found: error
+
+  sign_nupkg:
+    name: Sign NuGet package binaries
+    runs-on: windows-latest
+    needs:
+      - preflight
+      - pack_nuget
+      - pack_dotnet_tool
+    environment: ${{ needs.preflight.outputs.publish_env }}
+
+    steps:
+      - name: Download unsigned build NuGet artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: devolutions-cirup-build-nupkg-unsigned
+          path: dist/unsigned/build
+
+      - name: Download unsigned dotnet tool NuGet artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: devolutions-cirup-tool-nupkg-unsigned
+          path: dist/unsigned/tool
+
+      - name: Resolve signing mode
+        id: signing_mode
+        shell: pwsh
+        env:
+          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
+          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
+          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
+          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
+        run: |
+          $dryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry_run }}')
+          $publishEnv = '${{ needs.preflight.outputs.publish_env }}'
+          $isTestSigning = $publishEnv -eq 'publish-test'
+
+          $requiredValues = @(
+            $env:CODE_SIGNING_KEYVAULT_URL,
+            $env:AZURE_TENANT_ID,
+            $env:CODE_SIGNING_CLIENT_ID,
+            $env:CODE_SIGNING_CLIENT_SECRET,
+            $env:CODE_SIGNING_CERTIFICATE_NAME,
+            $env:CODE_SIGNING_TIMESTAMP_SERVER
+          )
+
+          $hasSigningSecrets = $true
+          foreach ($value in $requiredValues) {
+            if ([string]::IsNullOrWhiteSpace($value)) {
+              $hasSigningSecrets = $false
+              break
+            }
+          }
+
+          if ($isTestSigning) {
+            $shouldSign = $hasSigningSecrets
+          }
+          else {
+            $shouldSign = -not $dryRun -and $hasSigningSecrets
+          }
+
+          "dry_run=$($dryRun.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "should_sign=$($shouldSign.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          if ($isTestSigning -and -not $hasSigningSecrets) {
+            throw 'Code signing secrets are required for test code signing in publish-test.'
+          }
+
+          if (-not $dryRun -and -not $hasSigningSecrets) {
+            throw 'Code signing secrets are required for non-dry-run release jobs.'
+          }
+
+          Write-Host "NuGet package signing dry-run mode: $dryRun"
+          Write-Host "NuGet package binaries will be signed: $shouldSign"
+
+      - name: Install AzureSignTool
+        if: steps.signing_mode.outputs.should_sign == 'true'
+        shell: pwsh
+        run: |
+          $toolPath = Join-Path $env:USERPROFILE '.dotnet\tools\AzureSignTool.exe'
+          if (Test-Path -Path $toolPath) {
+            dotnet tool update --global AzureSignTool
+          }
+          else {
+            dotnet tool install --global AzureSignTool
+          }
+
+      - name: Sign package binaries and prepare signed nupkgs
+        shell: pwsh
+        env:
+          SHOULD_SIGN: ${{ steps.signing_mode.outputs.should_sign }}
+          CODE_SIGNING_KEYVAULT_URL: ${{ secrets.CODE_SIGNING_KEYVAULT_URL }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
+          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
+          CODE_SIGNING_CERTIFICATE_NAME: ${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}
+          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
+        run: |
+          $shouldSign = [System.Boolean]::Parse($env:SHOULD_SIGN)
+          $unsignedPackages = Get-ChildItem -Path 'dist/unsigned' -Recurse -File -Filter '*.nupkg' | Sort-Object Name
+          if (-not $unsignedPackages) {
+            throw 'No unsigned NuGet packages found under dist/unsigned.'
+          }
+
+          $signedOutputRoot = Join-Path $PWD 'dist/signed'
+          if (Test-Path -Path $signedOutputRoot) {
+            Remove-Item -Path $signedOutputRoot -Recurse -Force
+          }
+
+          New-Item -Path $signedOutputRoot -ItemType Directory -Force | Out-Null
+          $toolPath = Join-Path $env:USERPROFILE '.dotnet\tools\AzureSignTool.exe'
+
+          foreach ($package in $unsignedPackages) {
+            $extractDir = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString('N'))
+            New-Item -Path $extractDir -ItemType Directory -Force | Out-Null
+
+            Expand-Archive -Path $package.FullName -DestinationPath $extractDir -Force
+
+            if ($shouldSign) {
+              $windowsBinaries = Get-ChildItem -Path $extractDir -Recurse -File | Where-Object {
+                ($_.Extension -in '.exe', '.dll') -and ($_.FullName -match '(\\|/)win-(x64|arm64)(\\|/)')
+              }
+
+              foreach ($binary in $windowsBinaries) {
+                & $toolPath sign `
+                  -kvt "$env:AZURE_TENANT_ID" `
+                  -kvu "$env:CODE_SIGNING_KEYVAULT_URL" `
+                  -kvi "$env:CODE_SIGNING_CLIENT_ID" `
+                  -kvs "$env:CODE_SIGNING_CLIENT_SECRET" `
+                  -kvc "$env:CODE_SIGNING_CERTIFICATE_NAME" `
+                  -tr "$env:CODE_SIGNING_TIMESTAMP_SERVER" `
+                  -v `
+                  "$($binary.FullName)"
+              }
+            }
+
+            $signedPackagePath = Join-Path $signedOutputRoot $package.Name
+            if (Test-Path -Path $signedPackagePath) {
+              Remove-Item -Path $signedPackagePath -Force
+            }
+
+            Compress-Archive -Path (Join-Path $extractDir '*') -DestinationPath $signedPackagePath -CompressionLevel Optimal
+            Remove-Item -Path $extractDir -Recurse -Force
+          }
+
+      - name: Upload signed build NuGet artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devolutions-cirup-build-nupkg
+          path: dist/signed/Devolutions.Cirup.Build.*.nupkg
+          if-no-files-found: error
+
+      - name: Upload signed dotnet tool NuGet artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devolutions-cirup-tool-nupkg
+          path: dist/signed/Devolutions.Cirup.Tool*.nupkg
           if-no-files-found: error
 
   publish_nuget:
@@ -595,8 +766,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - preflight
-      - pack_nuget
-      - pack_dotnet_tool
+      - sign_nupkg
     if: needs.preflight.outputs.publish_nuget == 'true'
     environment: ${{ needs.preflight.outputs.publish_env }}
     permissions:
@@ -623,10 +793,18 @@ jobs:
 
           Write-Host "NuGet dry-run mode: $dryRun"
 
-      - name: Download package artifacts
+      - name: Download signed build NuGet artifact
         if: steps.publish_mode.outputs.dry_run == 'true' || steps.publish_mode.outputs.has_login_user == 'true'
         uses: actions/download-artifact@v4
         with:
+          name: devolutions-cirup-build-nupkg
+          path: dist
+
+      - name: Download signed dotnet tool NuGet artifact
+        if: steps.publish_mode.outputs.dry_run == 'true' || steps.publish_mode.outputs.has_login_user == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: devolutions-cirup-tool-nupkg
           path: dist
 
       - name: Setup .NET SDK

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
+obj/
+bin/
 .vscode/
 .idea/
 target/
-nuget/tool/bin/
-nuget/tool/obj/


### PR DESCRIPTION
## Summary
- route release environment by source branch: `master` -> `publish-prod`, non-master -> `publish-test`
- force dry-run when using `publish-test` to prevent real publishing with test signing
- keep test code signing enabled in `publish-test`
- add sign-once/reuse flow for NuGet packages:
  - pack jobs publish `*-unsigned` nupkg artifacts
  - `sign_nupkg` signs package Windows binaries once
  - publish jobs consume only signed nupkg artifacts
- keep Windows zip signing in dedicated signing job

## Validation
- workflow dry-run validation run succeeded: https://github.com/Devolutions/cirup-rs/actions/runs/22677209592
- verified final uploaded signed artifacts; Windows executables/dlls in signed zips/nupkgs are signed (no unsigned files in signed artifact set)