### PR TITLE
Fix release dispatch to create missing tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.info.outputs.release_tag }}
+      build_ref: ${{ steps.info.outputs.build_ref }}
       publish_env: ${{ steps.info.outputs.publish_env }}
       publish_nuget: ${{ steps.info.outputs.publish_nuget }}
       dry_run: ${{ steps.info.outputs.dry_run }}
@@ -63,10 +64,13 @@ jobs:
 
           $eventName = '${{ github.event_name }}'
           $githubRef = '${{ github.ref }}'
+          $runSha = '${{ github.sha }}'
           $sourceBranch = '${{ github.ref_name }}'
+          $buildRef = $runSha
 
           if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
             $releaseTag = '${{ github.ref_name }}'
+            $buildRef = $releaseTag
 
             git fetch --prune --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
             $containsMaster = @(git branch -r --contains '${{ github.sha }}' | ForEach-Object { $_.Trim() }) -contains 'origin/master'
@@ -112,12 +116,36 @@ jobs:
             $dryRun = $true
           }
 
+          if ($eventName -eq 'workflow_dispatch' -and $sourceBranch -eq 'master' -and -not $dryRun) {
+            git fetch --tags --force origin
+            git show-ref --tags --verify --quiet "refs/tags/$releaseTag"
+            $tagExists = $LASTEXITCODE -eq 0
+
+            if ($tagExists) {
+              $existingTagCommit = (git rev-list -n 1 "$releaseTag").Trim()
+              if ($existingTagCommit -ne $runSha) {
+                throw "Tag '$releaseTag' already exists at $existingTagCommit (expected $runSha)."
+              }
+
+              Write-Host "::notice::Tag $releaseTag already exists at $runSha"
+            }
+            else {
+              git tag "$releaseTag" "$runSha"
+              git push origin "refs/tags/$releaseTag"
+              Write-Host "::notice::Created tag $releaseTag at $runSha"
+            }
+
+            $buildRef = $releaseTag
+          }
+
           "release_tag=$releaseTag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "build_ref=$buildRef" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "publish_env=$publishEnv" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "publish_nuget=$($publishNuget.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "dry_run=$($dryRun.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
           Write-Host "::notice::Release tag: $releaseTag"
+          Write-Host "::notice::Build ref: $buildRef"
           Write-Host "::notice::Source branch: $sourceBranch"
           Write-Host "::notice::Publish environment: $publishEnv"
           Write-Host "::notice::Publish NuGet: $($publishNuget.ToString().ToLowerInvariant())"
@@ -172,7 +200,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.preflight.outputs.release_tag }}
+          ref: ${{ needs.preflight.outputs.build_ref }}
 
       - name: Install Rust toolchain
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
-      tag:
-        description: Release tag to build/publish (for example v0.1.0)
+      version:
+        description: Release version to build/publish (for example 0.4.0)
         required: true
         type: string
       publish_nuget:
@@ -67,8 +67,10 @@ jobs:
           $runSha = '${{ github.sha }}'
           $sourceBranch = '${{ github.ref_name }}'
           $buildRef = $runSha
+          $isTagPush = $eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')
+          $isWorkflowDispatch = $eventName -eq 'workflow_dispatch'
 
-          if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
+          if ($isTagPush) {
             $releaseTag = '${{ github.ref_name }}'
             $buildRef = $releaseTag
 
@@ -82,21 +84,36 @@ jobs:
             }
           }
           else {
-            $releaseTag = '${{ github.event.inputs.tag }}'
+            $releaseVersion = '${{ github.event.inputs.version }}'.Trim()
+            if ([string]::IsNullOrWhiteSpace($releaseVersion)) {
+              throw 'Workflow input version is required.'
+            }
+
+            if ($releaseVersion.StartsWith('v')) {
+              $releaseVersion = $releaseVersion.Substring(1)
+            }
+
+            if ($releaseVersion -notmatch '^\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$') {
+              throw "Invalid version format: $releaseVersion (expected 1.2.3 or 1.2.3-suffix)."
+            }
+
+            $releaseTag = "v$releaseVersion"
           }
 
           if (-not $releaseTag.StartsWith('v')) {
             throw "Release tag must start with 'v'. Actual: $releaseTag"
           }
 
-          if ($sourceBranch -eq 'master') {
+          $isMasterBranch = $sourceBranch -eq 'master'
+
+          if ($isMasterBranch) {
             $publishEnv = 'publish-prod'
           }
           else {
             $publishEnv = 'publish-test'
           }
 
-          if ($eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')) {
+          if ($isTagPush) {
             $publishNuget = $true
           }
           else {
@@ -104,38 +121,16 @@ jobs:
           }
 
           $dryRun = $false
-          if ($eventName -eq 'workflow_dispatch') {
+          if ($isWorkflowDispatch) {
             $dryRun = Parse-BoolOrDefault '${{ github.event.inputs.dry_run_nuget }}' $true
           }
 
-          if ($publishEnv -ne 'publish-prod') {
+          if (-not $isMasterBranch) {
             $dryRun = $true
           }
 
           if (-not $publishNuget) {
             $dryRun = $true
-          }
-
-          if ($eventName -eq 'workflow_dispatch' -and $sourceBranch -eq 'master' -and -not $dryRun) {
-            git fetch --tags --force origin
-            git show-ref --tags --verify --quiet "refs/tags/$releaseTag"
-            $tagExists = $LASTEXITCODE -eq 0
-
-            if ($tagExists) {
-              $existingTagCommit = (git rev-list -n 1 "$releaseTag").Trim()
-              if ($existingTagCommit -ne $runSha) {
-                throw "Tag '$releaseTag' already exists at $existingTagCommit (expected $runSha)."
-              }
-
-              Write-Host "::notice::Tag $releaseTag already exists at $runSha"
-            }
-            else {
-              git tag "$releaseTag" "$runSha"
-              git push origin "refs/tags/$releaseTag"
-              Write-Host "::notice::Created tag $releaseTag at $runSha"
-            }
-
-            $buildRef = $releaseTag
           }
 
           "release_tag=$releaseTag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -539,7 +534,7 @@ jobs:
       - sign_windows
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
+      (github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Checkout
@@ -589,7 +584,7 @@ jobs:
       - sign_windows
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
+      (github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -62,43 +59,24 @@ jobs:
             }
           }
 
-          $eventName = '${{ github.event_name }}'
-          $githubRef = '${{ github.ref }}'
           $runSha = '${{ github.sha }}'
           $sourceBranch = '${{ github.ref_name }}'
           $buildRef = $runSha
-          $isTagPush = $eventName -eq 'push' -and $githubRef.StartsWith('refs/tags/v')
-          $isWorkflowDispatch = $eventName -eq 'workflow_dispatch'
 
-          if ($isTagPush) {
-            $releaseTag = '${{ github.ref_name }}'
-            $buildRef = $releaseTag
-
-            git fetch --prune --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
-            $containsMaster = @(git branch -r --contains '${{ github.sha }}' | ForEach-Object { $_.Trim() }) -contains 'origin/master'
-            if ($containsMaster) {
-              $sourceBranch = 'master'
-            }
-            else {
-              $sourceBranch = 'non-master'
-            }
+          $releaseVersion = '${{ github.event.inputs.version }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($releaseVersion)) {
+            throw 'Workflow input version is required.'
           }
-          else {
-            $releaseVersion = '${{ github.event.inputs.version }}'.Trim()
-            if ([string]::IsNullOrWhiteSpace($releaseVersion)) {
-              throw 'Workflow input version is required.'
-            }
 
-            if ($releaseVersion.StartsWith('v')) {
-              $releaseVersion = $releaseVersion.Substring(1)
-            }
-
-            if ($releaseVersion -notmatch '^\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$') {
-              throw "Invalid version format: $releaseVersion (expected 1.2.3 or 1.2.3-suffix)."
-            }
-
-            $releaseTag = "v$releaseVersion"
+          if ($releaseVersion.StartsWith('v')) {
+            $releaseVersion = $releaseVersion.Substring(1)
           }
+
+          if ($releaseVersion -notmatch '^\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$') {
+            throw "Invalid version format: $releaseVersion (expected 1.2.3 or 1.2.3-suffix)."
+          }
+
+          $releaseTag = "v$releaseVersion"
 
           if (-not $releaseTag.StartsWith('v')) {
             throw "Release tag must start with 'v'. Actual: $releaseTag"
@@ -113,17 +91,9 @@ jobs:
             $publishEnv = 'publish-test'
           }
 
-          if ($isTagPush) {
-            $publishNuget = $true
-          }
-          else {
-            $publishNuget = Parse-BoolOrDefault '${{ github.event.inputs.publish_nuget }}' $false
-          }
+          $publishNuget = Parse-BoolOrDefault '${{ github.event.inputs.publish_nuget }}' $false
 
-          $dryRun = $false
-          if ($isWorkflowDispatch) {
-            $dryRun = Parse-BoolOrDefault '${{ github.event.inputs.dry_run_nuget }}' $true
-          }
+          $dryRun = Parse-BoolOrDefault '${{ github.event.inputs.dry_run_nuget }}' $true
 
           if (-not $isMasterBranch) {
             $dryRun = $true
@@ -512,10 +482,8 @@ jobs:
             $createArgs += "dist/checksums.txt"
             $createArgs += "--generate-notes"
 
-            if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
-              $createArgs += "--target"
-              $createArgs += "$env:RELEASE_TARGET"
-            }
+            $createArgs += "--target"
+            $createArgs += "$env:RELEASE_TARGET"
 
             gh release create @createArgs
           }
@@ -532,9 +500,6 @@ jobs:
     needs:
       - preflight
       - sign_windows
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Checkout
@@ -582,9 +547,6 @@ jobs:
     needs:
       - preflight
       - sign_windows
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- make `workflow_dispatch` releases from `master` create/push the requested release tag when needed
- add preflight output `build_ref` and use it for build checkout
- keep tag push behavior unchanged while avoiding matrix checkout failures when a tag does not yet exist

## Why
The latest master release run failed at checkout because `ref: v0.4.0` did not exist yet.